### PR TITLE
Fix: Resolve multiple errors in Sinoptico module

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -571,6 +571,23 @@ const dataService = {
         }
     },
 
+    getDocById: async (collectionName, docId) => {
+        try {
+            const docRef = doc(db, collectionName, docId);
+            const docSnap = await getDoc(docRef);
+            if (docSnap.exists()) {
+                return { docId: docSnap.id, ...docSnap.data() };
+            } else {
+                console.warn(`Document with id ${docId} not found in ${collectionName}`);
+                return null;
+            }
+        } catch (error) {
+            console.error(`Error fetching document ${docId} from ${collectionName}:`, error);
+            uiService.showToast('Error al obtener el documento.', 'error');
+            return null;
+        }
+    },
+
     getData: async (collectionName, { filters = {}, sortColumn = 'id', sortDirection = 'asc', page = 1, itemsPerPage = 10, startAfterDoc = null }) => {
         const collRef = collection(db, collectionName);
         const schema = schemas[collectionName] || schemas.default;

--- a/public/js/sinoptico.js
+++ b/public/js/sinoptico.js
@@ -85,7 +85,7 @@ export const sinopticoModule = {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <!-- Fancytree llenará este tbody -->
+                                    <tr style="display:none;"><td colspan="4"></td></tr>
                                 </tbody>
                             </table>
                         </div>
@@ -98,10 +98,10 @@ export const sinopticoModule = {
                              <div class="flex items-center space-x-2">
                                 <span class="text-sm font-medium text-slate-700">Filtrar Nivel:</span>
                                 <div id="level-filter-container" class="flex items-center space-x-2">
-                                    <label class="inline-flex items-center"><input type="checkbox" class="level-filter" value="1" checked> <span class="ml-1 text-xs">1</span></label>
-                                    <label class="inline-flex items-center"><input type="checkbox" class="level-filter" value="2" checked> <span class="ml-1 text-xs">2</span></label>
-                                    <label class="inline-flex items-center"><input type="checkbox" class="level-filter" value="3" checked> <span class="ml-1 text-xs">3</span></label>
-                                    <label class="inline-flex items-center"><input type="checkbox" class="level-filter" value="4" checked> <span class="ml-1 text-xs">4+</span></label>
+                                    <label class="inline-flex items-center"><input type="checkbox" name="level-filter" class="level-filter" value="1" checked> <span class="ml-1 text-xs">1</span></label>
+                                    <label class="inline-flex items-center"><input type="checkbox" name="level-filter" class="level-filter" value="2" checked> <span class="ml-1 text-xs">2</span></label>
+                                    <label class="inline-flex items-center"><input type="checkbox" name="level-filter" class="level-filter" value="3" checked> <span class="ml-1 text-xs">3</span></label>
+                                    <label class="inline-flex items-center"><input type="checkbox" name="level-filter" class="level-filter" value="4" checked> <span class="ml-1 text-xs">4+</span></label>
                                 </div>
                             </div>
                         </div>
@@ -633,7 +633,7 @@ export const sinopticoModule = {
         saveBtn.innerHTML = `<i data-lucide="loader" class="animate-spin h-5 w-5 mx-auto"></i> Guardando...`;
         lucide.createIcons();
 
-        const tree = jQuery('#sinoptico-tree-container').fancytree('getTree');
+        const tree = $.ui.fancytree.getTree('#sinoptico-tree-container');
         const treeData = tree.toDict(true, (nodeDict) => {
             const cleanNode = {
                 key: nodeDict.key,
@@ -674,7 +674,7 @@ export const sinopticoModule = {
      * Abre un modal para añadir un nuevo componente al nodo activo.
      */
     _addNode() {
-        const tree = jQuery('#sinoptico-tree-container').fancytree('getTree');
+        const tree = $.ui.fancytree.getTree('#sinoptico-tree-container');
         const activeNode = tree.getActiveNode();
 
         if (!activeNode) {
@@ -715,7 +715,7 @@ export const sinopticoModule = {
      * Elimina el nodo activo del árbol.
      */
     _removeNode() {
-        const tree = jQuery('#sinoptico-tree-container').fancytree('getTree');
+        const tree = $.ui.fancytree.getTree('#sinoptico-tree-container');
         const activeNode = tree.getActiveNode();
 
         if (!activeNode) {
@@ -741,7 +741,7 @@ export const sinopticoModule = {
      * Aplica el filtro de nivel al árbol.
      */
     _applyFilter() {
-        const tree = jQuery('#sinoptico-tree-container').fancytree('getTree');
+        const tree = $.ui.fancytree.getTree('#sinoptico-tree-container');
         if (!tree || !tree.filterNodes) return;
 
         const checkedLevels = Array.from(document.querySelectorAll('.level-filter:checked')).map(cb => parseInt(cb.value, 10));
@@ -794,7 +794,7 @@ export const sinopticoModule = {
 
         const historyTab = contentContainer.querySelector('[data-tab="history"]');
         historyTab.addEventListener('click', async () => {
-            contentContainer.querySelector('.tab-content-container').innerHTML = `<div classp-6"><div class="loading-spinner mx-auto"></div></div>`;
+            contentContainer.querySelector('.tab-content-container').innerHTML = `<div class="p-6"><div class="loading-spinner mx-auto"></div></div>`;
             const history = await this.dataService.getVersionHistory(collectionName, docId);
             contentContainer.querySelector('.tab-content-container').innerHTML = this._generateHistoryTabContent(history);
             lucide.createIcons();


### PR DESCRIPTION
This commit addresses several issues reported in the sinoptico module:

1.  **Fix critical error on item selection:** A `TypeError` occurred because the `getDocById` function was missing from `dataService`. This function has been added to `main.js`, allowing the details modal to load correctly.
2.  **Update deprecated Fancytree method:** Replaced all calls to the deprecated `jQuery(...).fancytree('getTree')` with the recommended `$.ui.fancytree.getTree(...)`.
3.  **Fix Fancytree column mismatch warning:** Added a hidden, empty row with the correct colspan to the `<tbody>` of the Fancytree table to prevent the column count mismatch warning on initialization.
4.  **Fix missing form field attribute:** Added `name` attributes to the level filter checkboxes to comply with HTML best practices and remove browser warnings.
5.  **Fix minor typo:** Corrected a typo in a class name within the detail modal's loading spinner.