### PR TITLE
refactor(sinoptico): Overhaul view for better hierarchy and data

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -239,7 +239,7 @@
         </header>
 
         <main class="flex-1 overflow-y-auto custom-scrollbar">
-            <div class="w-full max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+            <div class="w-full max-w-full mx-auto px-4 sm:px-6 lg:px-8 py-10">
                 <div id="view-header-container" class="mb-8"></div>
                 <div id="view-body-container"></div>
             </div>


### PR DESCRIPTION
This commit completely refactors the product synoptic view to address several of your requests for improvement.

The key changes are:
- Replaced the table-based tree with a standard hierarchical tree, enabling the use of connector lines to visually represent the product structure.
- Updated the iconography to be more representative of the automotive industry, using icons like 'car-front', 'cog', and 'component'.
- Modified the layout to utilize the full screen width and increased the vertical height of the tree container for better use of space.
- Enriched the data displayed for each node. While the columnar layout was removed, key information such as version, material, color, supplier, and process is now displayed inline with the node title.
- Removed the now-obsolete table sorting functionality.