### PR TITLE
refactor(sinoptico): Overhaul view for better hierarchy and data

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -95,17 +95,6 @@
             font-style: italic;
         }
 
-        /* --- Estilos para Fancytree Connectors --- */
-        .fancytree-ext-connectors .fancytree-container {
-            border: none;
-        }
-        .fancytree-ext-connectors .fancytree-node,
-        .fancytree-ext-connectors .fancytree-expander {
-            background-image: url(https://cdn.jsdelivr.net/npm/jquery.fancytree@2.38.1/dist/skin-win8/icons.gif);
-        }
-        .fancytree-ext-connectors .fancytree-expander {
-            background-position: 0 0;
-        }
     </style>
 </head>
 <body class="bg-slate-50">
@@ -274,6 +263,7 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <link href="https://cdn.jsdelivr.net/npm/jquery.fancytree@2.38.1/dist/skin-win8/ui.fancytree.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/jquery.fancytree@2.38.1/dist/jquery.fancytree-all-deps.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery.fancytree@2.38.1/dist/modules/jquery.fancytree.connectors.js"></script>
     
     <!-- SCRIPT PRINCIPAL DE LA APLICACIÓN (se carga último) -->
     <script type="module" src="js/main.js"></script>


### PR DESCRIPTION
I've completely refactored the product synoptic view to address several of your requests for improvement.

The key changes are:
- Replaced the table-based tree with a standard hierarchical tree, enabling the use of connector lines to visually represent the product structure.
- Updated the iconography to be more representative of the automotive industry, using icons like 'car-front', 'cog', and 'component'.
- Modified the layout to utilize the full screen width and increased the vertical height of the tree container for better use of space.
- Enriched the data displayed for each node. While the columnar layout was removed, key information such as version, material, color, supplier, and process is now displayed inline with the node title.
- Removed the now-obsolete table sorting functionality.

This also fixed multiple follow-up bugs, including:
- Loading the Fancytree 'connectors' extension JavaScript file, which was missing from the main dependency bundle and caused the extension to not be registered.
- A TypeError from a call to a removed sorting function.
- A TypeError from attempting to access `innerHTML` on a null `tbody` element.
- A TypeError from incorrectly assigning properties to `node.data` on a plain object.