### PR TITLE
fix(sinoptico): Correct Mermaid.js library import

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -214,10 +214,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tinycolor/1.6.0/tinycolor.min.js"></script>
 
     <!-- Mermaid JS (para diagramas) -->
-    <script type="module">
-        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.js';
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
         mermaid.initialize({ startOnLoad: false });
-        window.mermaid = mermaid;
     </script>
     
     <!-- SCRIPT PRINCIPAL DE LA APLICACIÓN (se carga último) -->


### PR DESCRIPTION
The previous commit introduced a refactor to use Mermaid.js but used an incorrect CDN link for the library, which resulted in a 404 error and caused the script to fail.

This commit corrects the way the Mermaid.js library is loaded in `public/index.html`. It replaces the non-functional `<script type="module">` block with a standard `<script>` tag pointing to the correct, stable CDN URL for the library.

This resolves the 404 error and the subsequent `TypeError` in `sinoptico.js`, allowing the diagrams to be rendered correctly.