### PR TITLE
Fix: Correct React Router nesting and improve code

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ function App() {
 
       {/* Protected Routes */}
       <Route
-        path="/*"
+        path="/"
         element={
           <PrivateRoute>
             <Layout />
@@ -29,9 +29,8 @@ function App() {
       >
         {/* All routes inside Layout will be protected */}
         <Route index element={<DashboardPage />} />
-        <Route path="/clientes" element={<ClientesPage />} />
-        <Route path="/sinoptico" element={<SinopticoPage />} /> {/* Add the new route */}
-        {/* Other protected routes like /flowchart will be added here */}
+        <Route path="clientes" element={<ClientesPage />} />
+        <Route path="sinoptico" element={<SinopticoPage />} /> {/* Add the new route */}
       </Route>
     </Routes>
   );

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -58,7 +58,7 @@ function Layout() {
               </div>
 
               <NavLink to="/sinoptico" className={navLinkClasses}>Sinóptico</NavLink>
-              <NavLink to="/flowchart" className={navLinkClasses}>Flujogramas</NavLink>
+              {/* <NavLink to="/flowchart" className={navLinkClasses}>Flujogramas</NavLink> */}
             </div>
 
             {currentUser && (


### PR DESCRIPTION
- Resolves a critical routing error by changing the parent route path from '/*' to '/' and making child route paths relative.
- This aligns the routing configuration with react-router-dom v6 conventions for nested routes.
- Comments out a NavLink for an unimplemented '/flowchart' route to prevent dead links.