### PR TITLE
fix: Resolve login error and apply CSS styling

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 }

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -34,7 +34,7 @@ function AuthProvider({ children }) {
     });
   }
 
-  function login(email, password) {
+  function signIn(email, password) {
     return signInWithEmailAndPassword(auth, email, password);
   }
 
@@ -58,7 +58,7 @@ function AuthProvider({ children }) {
   const value = {
     currentUser,
     register,
-    login,
+    signIn,
     logout,
     resetPassword,
   };

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -7,7 +7,7 @@ function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
-  const { login } = useAuth();
+  const { signIn } = useAuth();
   const navigate = useNavigate();
   const { showToast } = useToast();
 
@@ -16,7 +16,7 @@ function LoginPage() {
     setLoading(true);
 
     try {
-      await login(email, password);
+      await signIn(email, password);
       showToast('Login successful!', 'success');
       navigate('/');
     } catch (error) {
@@ -46,6 +46,7 @@ function LoginPage() {
               onChange={(e) => setEmail(e.target.value)}
               className="shadow appearance-none border rounded w-full py-2 px-3 text-slate-700 leading-tight focus:outline-none focus:shadow-outline"
               required
+              autoComplete="email"
             />
           </div>
           <div className="mb-6">
@@ -62,6 +63,7 @@ function LoginPage() {
               onChange={(e) => setPassword(e.target.value)}
               className="shadow appearance-none border rounded w-full py-2 px-3 text-slate-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
               required
+              autoComplete="current-password"
             />
           </div>
           <div className="flex items-center justify-between">


### PR DESCRIPTION
This commit addresses three issues you reported:

1. A `TypeError` during login is resolved by renaming the `login` function in the auth context to `signIn` to prevent potential naming conflicts.

2. The issue of styles not being applied is fixed by correcting the `postcss.config.js` to properly load the `tailwindcss` plugin.

3. A browser warning is resolved by adding the `autocomplete` attribute to the login form fields.