### PR TITLE
fix(imports): Correct import path for useAuth hook

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { Button, Typography, Box } from '@mui/material';
 


### PR DESCRIPTION
Updates the import path for the `useAuth` hook in `DashboardPage.jsx`.

This resolves a build error caused by a previous refactoring where the `useAuth` hook was moved to its own file (`src/hooks/useAuth.js`), but the import path in `DashboardPage.jsx` was not updated accordingly.