### PR TITLE
fix: Pin AG Grid dependencies to compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "^31.3.2",
-    "@ag-grid-community/react": "^31.3.2",
-    "@ag-grid-enterprise/column-tool-panel": "^31.3.2",
-    "@ag-grid-enterprise/menu": "^31.3.2",
-    "@ag-grid-enterprise/row-grouping": "^31.3.2",
-    "@ag-grid-enterprise/set-filter": "^31.3.2",
+    "@ag-grid-community/client-side-row-model": "31.3.2",
+    "@ag-grid-community/react": "31.3.2",
+    "@ag-grid-enterprise/column-tool-panel": "31.3.2",
+    "@ag-grid-enterprise/menu": "31.3.2",
+    "@ag-grid-enterprise/row-grouping": "31.3.2",
+    "@ag-grid-enterprise/set-filter": "31.3.2",
     "@headlessui/react": "^2.0.0",
     "@heroicons/react": "^2.1.3",
     "@tailwindcss/vite": "^4.1.12",


### PR DESCRIPTION
Updates `package.json` to pin all `@ag-grid-*` packages to exact version `31.3.2`.

This resolves the `ERESOLVE` peer dependency conflict that occurs when `npm` installs a newer patch version of AG Grid that is not officially marked as compatible with React 19. By pinning the version, we ensure a stable and correct dependency tree is installed, allowing the project to be built and run without dependency errors.