### PR TITLE
fix(grid): Resolve AG Grid warnings and modal crash

### DIFF
--- a/src/components/DataGrid.jsx
+++ b/src/components/DataGrid.jsx
@@ -9,6 +9,8 @@ function DataGrid({
   columnDefs,
   onGridReady,
   onSelectionChanged,
+  loading,
+  frameworkComponents,
 }) {
   const defaultColDef = {
     sortable: true,
@@ -25,11 +27,12 @@ function DataGrid({
         defaultColDef={defaultColDef}
         onGridReady={onGridReady}
         onSelectionChanged={onSelectionChanged}
-        rowSelection="single"
         getRowId={params => params.data.id}
         overlayLoadingTemplate='<span class="ag-overlay-loading-center">Cargando...</span>'
         overlayNoRowsTemplate='<span class="ag-overlay-no-rows-center">No hay datos para mostrar.</span>'
         domLayout='autoHeight'
+        loading={loading}
+        components={frameworkComponents}
       />
     </div>
   );

--- a/src/pages/InsumosPage.jsx
+++ b/src/pages/InsumosPage.jsx
@@ -4,7 +4,6 @@ import InsumoModal from '../components/InsumoModal';
 import ConfirmDialog from '../components/ConfirmDialog';
 import DataGrid from '../components/DataGrid';
 import { PlusIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { Transition } from '@headlessui/react';
 
 const ActionsCellRenderer = ({ data, onEdit, onDelete }) => (
   <div className="flex items-center justify-end space-x-2">
@@ -23,19 +22,19 @@ function InsumosPage() {
   const [editingInsumo, setEditingInsumo] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deletingInsumoId, setDeletingInsumoId] = useState(null);
-  const [gridApi, setGridApi] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   const fetchInsumos = useCallback(async () => {
+    setLoading(true);
     try {
-      if (gridApi) gridApi.showLoadingOverlay();
       const data = await getInsumos();
       setInsumos(data);
     } catch (error) {
       console.error("Error fetching supplies:", error);
     } finally {
-      if (gridApi) gridApi.hideOverlay();
+      setLoading(false);
     }
-  }, [gridApi]);
+  }, []);
 
   useEffect(() => {
     fetchInsumos();
@@ -81,10 +80,6 @@ function InsumosPage() {
     }
   };
 
-  const onGridReady = (params) => {
-    setGridApi(params.api);
-  };
-
   const columnDefs = useMemo(() => [
     { headerName: "Código", field: "codigo", flex: 1, sortable: true, filter: true },
     { headerName: "Descripción", field: "descripcion", flex: 2, sortable: true, filter: true },
@@ -120,30 +115,19 @@ function InsumosPage() {
         <DataGrid
           rowData={insumos}
           columnDefs={columnDefs}
-          onGridReady={onGridReady}
           frameworkComponents={{
             actionsCellRenderer: ActionsCellRenderer,
           }}
+          loading={loading}
         />
       </div>
 
-      <Transition
-        show={modalOpen}
-        as={React.Fragment}
-        enter="transition-opacity duration-300"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-300"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <InsumoModal
-          open={modalOpen}
-          onClose={handleCloseModal}
-          onSave={handleSaveInsumo}
-          insumo={editingInsumo}
-        />
-      </Transition>
+      <InsumoModal
+        open={modalOpen}
+        onClose={handleCloseModal}
+        onSave={handleSaveInsumo}
+        insumo={editingInsumo}
+      />
 
       <ConfirmDialog
         open={confirmOpen}

--- a/src/pages/ProductosPage.jsx
+++ b/src/pages/ProductosPage.jsx
@@ -4,7 +4,6 @@ import ProductoModal from '../components/ProductoModal';
 import ConfirmDialog from '../components/ConfirmDialog';
 import DataGrid from '../components/DataGrid';
 import { PlusIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { Transition } from '@headlessui/react';
 
 const ActionsCellRenderer = ({ data, onEdit, onDelete }) => (
   <div className="flex items-center justify-end space-x-2">
@@ -23,19 +22,19 @@ function ProductosPage() {
   const [editingProducto, setEditingProducto] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deletingProductoId, setDeletingProductoId] = useState(null);
-  const [gridApi, setGridApi] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   const fetchProductos = useCallback(async () => {
+    setLoading(true);
     try {
-      if (gridApi) gridApi.showLoadingOverlay();
       const data = await getProductos();
       setProductos(data);
     } catch (error) {
       console.error("Error fetching products:", error);
     } finally {
-      if (gridApi) gridApi.hideOverlay();
+      setLoading(false);
     }
-  }, [gridApi]);
+  }, []);
 
   useEffect(() => {
     fetchProductos();
@@ -81,10 +80,6 @@ function ProductosPage() {
     }
   };
 
-  const onGridReady = (params) => {
-    setGridApi(params.api);
-  };
-
   const columnDefs = useMemo(() => [
     { headerName: "Código", field: "codigo", flex: 1, sortable: true, filter: true },
     { headerName: "Descripción", field: "descripcion", flex: 2, sortable: true, filter: true },
@@ -120,30 +115,19 @@ function ProductosPage() {
         <DataGrid
           rowData={productos}
           columnDefs={columnDefs}
-          onGridReady={onGridReady}
           frameworkComponents={{
             actionsCellRenderer: ActionsCellRenderer,
           }}
+          loading={loading}
         />
       </div>
 
-      <Transition
-        show={modalOpen}
-        as={React.Fragment}
-        enter="transition-opacity duration-300"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-300"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <ProductoModal
-          open={modalOpen}
-          onClose={handleCloseModal}
-          onSave={handleSaveProducto}
-          producto={editingProducto}
-        />
-      </Transition>
+      <ProductoModal
+        open={modalOpen}
+        onClose={handleCloseModal}
+        onSave={handleSaveProducto}
+        producto={editingProducto}
+      />
 
       <ConfirmDialog
         open={confirmOpen}

--- a/src/pages/ProveedoresPage.jsx
+++ b/src/pages/ProveedoresPage.jsx
@@ -4,7 +4,6 @@ import ProveedorModal from '../components/ProveedorModal';
 import ConfirmDialog from '../components/ConfirmDialog';
 import DataGrid from '../components/DataGrid';
 import { PlusIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { Transition } from '@headlessui/react';
 
 const ActionsCellRenderer = ({ data, onEdit, onDelete }) => (
   <div className="flex items-center justify-end space-x-2">
@@ -23,19 +22,19 @@ function ProveedoresPage() {
   const [editingProveedor, setEditingProveedor] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deletingProveedorId, setDeletingProveedorId] = useState(null);
-  const [gridApi, setGridApi] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   const fetchProveedores = useCallback(async () => {
+    setLoading(true);
     try {
-      if (gridApi) gridApi.showLoadingOverlay();
       const data = await getProveedores();
       setProveedores(data);
     } catch (error) {
       console.error("Error fetching suppliers:", error);
     } finally {
-      if (gridApi) gridApi.hideOverlay();
+      setLoading(false);
     }
-  }, [gridApi]);
+  }, []);
 
   useEffect(() => {
     fetchProveedores();
@@ -81,10 +80,6 @@ function ProveedoresPage() {
     }
   };
 
-  const onGridReady = (params) => {
-    setGridApi(params.api);
-  };
-
   const columnDefs = useMemo(() => [
     { headerName: "Código", field: "codigo", flex: 1, sortable: true, filter: true },
     { headerName: "Descripción", field: "descripcion", flex: 2, sortable: true, filter: true },
@@ -120,30 +115,19 @@ function ProveedoresPage() {
         <DataGrid
           rowData={proveedores}
           columnDefs={columnDefs}
-          onGridReady={onGridReady}
           frameworkComponents={{
             actionsCellRenderer: ActionsCellRenderer,
           }}
+          loading={loading}
         />
       </div>
 
-      <Transition
-        show={modalOpen}
-        as={React.Fragment}
-        enter="transition-opacity duration-300"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-300"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <ProveedorModal
-          open={modalOpen}
-          onClose={handleCloseModal}
-          onSave={handleSaveProveedor}
-          proveedor={editingProveedor}
-        />
-      </Transition>
+      <ProveedorModal
+        open={modalOpen}
+        onClose={handleCloseModal}
+        onSave={handleSaveProveedor}
+        proveedor={editingProveedor}
+      />
 
       <ConfirmDialog
         open={confirmOpen}


### PR DESCRIPTION
This commit addresses several issues related to AG Grid and modal dialogs.

The `DataGrid` component has been updated to use modern AG Grid APIs. The deprecated `rowSelection` prop and `showLoadingOverlay` API calls have been replaced with the `loading` prop and correct component registration. This resolves the warnings and ensures the `actionsCellRenderer` is found, making the action buttons in the grid functional.

The application crash that occurred when opening a modal (e.g., "Añadir Proveedor") has been fixed by removing a redundant and conflicting `Transition` component from the page-level components.

Finally, unused state variables and handlers related to the old `gridApi` have been removed, cleaning up the code and resolving all linting errors.