### PR TITLE
feat: Add product code and fix action buttons

### DIFF
--- a/src/components/DataGrid.jsx
+++ b/src/components/DataGrid.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { AgGridReact } from '@ag-grid-community/react';
+import { ModuleRegistry } from '@ag-grid-community/core';
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
 
 import '@ag-grid-community/styles/ag-grid.css';
 import '@ag-grid-community/styles/ag-theme-alpine.css';
+
+ModuleRegistry.registerModules([ClientSideRowModelModule]);
 
 function DataGrid({
   rowData,
@@ -10,7 +14,7 @@ function DataGrid({
   onGridReady,
   onSelectionChanged,
   loading,
-  frameworkComponents,
+  components,
 }) {
   const defaultColDef = {
     sortable: true,
@@ -29,7 +33,7 @@ function DataGrid({
         onSelectionChanged={onSelectionChanged}
         getRowId={params => params.data.id}
         loading={loading}
-        frameworkComponents={frameworkComponents}
+        components={components}
         overlayLoadingTemplate='<span class="ag-overlay-loading-center">Cargando...</span>'
         overlayNoRowsTemplate='<span class="ag-overlay-no-rows-center">No hay datos para mostrar.</span>'
         domLayout='autoHeight'

--- a/src/components/ProductoModal.jsx
+++ b/src/components/ProductoModal.jsx
@@ -3,16 +3,19 @@ import { Dialog, Transition } from '@headlessui/react';
 
 const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
   const [formData, setFormData] = useState({
+    codigo: '',
     descripcion: '',
   });
 
   useEffect(() => {
     if (producto) {
       setFormData({
+        codigo: producto.codigo || '',
         descripcion: producto.descripcion || '',
       });
     } else {
       setFormData({
+        codigo: '',
         descripcion: '',
       });
     }
@@ -24,8 +27,8 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
   };
 
   const handleSave = () => {
-    if (!formData.descripcion) {
-      alert('Descripción es obligatoria.');
+    if (!formData.codigo || !formData.descripcion) {
+      alert('Código y Descripción son obligatorios.');
       return;
     }
     onSave(formData);
@@ -67,6 +70,19 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
                       Por favor, complete los detalles del producto.
                     </p>
                     <div className="space-y-4">
+                      <div>
+                        <label htmlFor="codigo" className="block text-sm font-medium text-gray-700">
+                          Código
+                        </label>
+                        <input
+                          type="text"
+                          name="codigo"
+                          id="codigo"
+                          value={formData.codigo}
+                          onChange={handleChange}
+                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                        />
+                      </div>
                       <div>
                         <label htmlFor="descripcion" className="block text-sm font-medium text-gray-700">
                           Descripción

--- a/src/pages/ProductosPage.jsx
+++ b/src/pages/ProductosPage.jsx
@@ -85,10 +85,11 @@ function ProductosPage() {
   };
 
   const handleInfo = (producto) => {
-    alert(`Información del Producto:\n\nDescripción: ${producto.descripcion}`);
+    alert(`Información del Producto:\n\nCódigo: ${producto.codigo}\nDescripción: ${producto.descripcion}`);
   };
 
   const columnDefs = useMemo(() => [
+    { headerName: "Código", field: "codigo", flex: 1, sortable: true, filter: true },
     { headerName: "Descripción", field: "descripcion", flex: 2, sortable: true, filter: true },
     {
       headerName: "Acciones",
@@ -124,7 +125,7 @@ function ProductosPage() {
           rowData={productos}
           columnDefs={columnDefs}
           loading={loading}
-          frameworkComponents={{
+          components={{
             actionsCellRenderer: ActionsCellRenderer,
           }}
         />


### PR DESCRIPTION
This commit introduces a new "codigo" (code) field for products. It updates the product modal to include an input for the code and adds a column to the products grid to display it.

Additionally, it fixes a bug where the action buttons (Info, Edit, Delete) were not being rendered in the products grid. This was resolved by updating the AG Grid configuration to use the `components` prop instead of the deprecated `frameworkComponents` prop for registering custom cell renderers.