### PR TITLE
feat: Add PropTypes validation to ClienteModal.jsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@heroicons/react": "^2.1.3",
         "@tailwindcss/vite": "^4.1.12",
         "firebase": "^12.1.0",
+        "prop-types": "^15.8.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@heroicons/react": "^2.1.3",
     "@tailwindcss/vite": "^4.1.12",
     "firebase": "^12.1.0",
+    "prop-types": "^15.8.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.0"

--- a/src/components/ClienteModal.jsx
+++ b/src/components/ClienteModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
+import PropTypes from 'prop-types';
 import { Dialog, Transition } from '@headlessui/react';
 
 const ClienteModal = forwardRef(({ open, onClose, onSave, cliente }, ref) => {
@@ -155,5 +156,14 @@ const ClienteModal = forwardRef(({ open, onClose, onSave, cliente }, ref) => {
     </Transition.Root>
   );
 });
+
+ClienteModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  cliente: PropTypes.object,
+};
+
+ClienteModal.displayName = 'ClienteModal';
 
 export default ClienteModal;


### PR DESCRIPTION
Adds PropTypes validation to the `ClienteModal.jsx` component to ensure it receives the correct properties, preventing potential errors and improving code robustness and maintainability.

- Installs and adds `prop-types` as a dependency.
- Imports `PropTypes` into the component.
- Defines `propTypes` for `open`, `onClose`, `onSave`, and `cliente`.