### PR TITLE
Refactor DataGrid component to be more generic

### DIFF
--- a/src/components/DataGrid.jsx
+++ b/src/components/DataGrid.jsx
@@ -15,13 +15,20 @@ function DataGrid({
   onSelectionChanged,
   loading,
   components,
+  getRowIdKey = 'id',
+  overlayLoadingTemplate = '<span class="ag-overlay-loading-center">Cargando...</span>',
+  overlayNoRowsTemplate = '<span class="ag-overlay-no-rows-center">No hay datos para mostrar.</span>',
+  defaultColDef: customDefaultColDef,
 }) {
   const defaultColDef = {
     sortable: true,
     filter: true,
     resizable: true,
     flex: 1,
+    ...customDefaultColDef,
   };
+
+  const getRowId = params => params.data[getRowIdKey];
 
   return (
     <div className="ag-theme-alpine" style={{ height: '100%', width: '100%' }}>
@@ -31,11 +38,11 @@ function DataGrid({
         defaultColDef={defaultColDef}
         onGridReady={onGridReady}
         onSelectionChanged={onSelectionChanged}
-        getRowId={params => params.data.id}
+        getRowId={getRowId}
         loading={loading}
         components={components}
-        overlayLoadingTemplate='<span class="ag-overlay-loading-center">Cargando...</span>'
-        overlayNoRowsTemplate='<span class="ag-overlay-no-rows-center">No hay datos para mostrar.</span>'
+        overlayLoadingTemplate={overlayLoadingTemplate}
+        overlayNoRowsTemplate={overlayNoRowsTemplate}
         domLayout='autoHeight'
       />
     </div>


### PR DESCRIPTION
This commit refactors the `DataGrid.jsx` component to make it more reusable and configurable.

The following changes were made:
- The `getRowId` function is now dynamically generated based on a `getRowIdKey` prop, which defaults to 'id' for backward compatibility.
- The `overlayLoadingTemplate` and `overlayNoRowsTemplate` messages are now configurable via props, with the original Spanish text as defaults.
- The component now accepts a `defaultColDef` prop, which is merged with the base defaults to allow for further customization.

These changes increase the component's flexibility without breaking existing implementations.

Note: The `npm run lint` command is currently failing due to a pre-existing peer dependency conflict between AG-Grid and React 19. This issue is unrelated to the changes in this commit.