### PR TITLE
Strengthen Firestore security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,6 +8,11 @@ service cloud.firestore {
       return get(/databases/$(database)/documents/usuarios/$(request.auth.uid)).data.role;
     }
 
+    // Función para verificar si el usuario es el propietario del documento.
+    function isOwner(res) {
+      return request.auth.uid == res.data.userId;
+    }
+
     // Reglas para la colección de Usuarios
     // Solo los administradores pueden leer la lista completa y modificar roles.
     // Cada usuario puede leer su propio documento de rol.
@@ -16,12 +21,27 @@ service cloud.firestore {
       allow write: if getUserRole() == 'administrador';
     }
 
-    // Reglas para TODAS las demás colecciones de datos (productos, clientes, etc.)
-    // La lectura está permitida para cualquier usuario autenticado.
-    // La escritura (crear, actualizar, borrar) solo para editores y administradores.
-    match /{document=**} {
-      allow read: if request.auth != null;
-      allow write: if getUserRole() in ['editor', 'administrador'] || request.auth.uid == 'NIFudxxXnea8HqFzeMpxY0kma5b2';
+    // Reglas para las colecciones de datos principales.
+    // El acceso de lectura y escritura se concede si el usuario es el propietario
+    // del documento o si tiene el rol de 'administrador'.
+    match /clientes/{documentId} {
+      allow read, write: if isOwner(resource) || getUserRole() == 'administrador';
+    }
+
+    match /insumos/{documentId} {
+      allow read, write: if isOwner(resource) || getUserRole() == 'administrador';
+    }
+
+    match /productos/{documentId} {
+      allow read, write: if isOwner(resource) || getUserRole() == 'administrador';
+    }
+
+    match /proveedores/{documentId} {
+      allow read, write: if isOwner(resource) || getUserRole() == 'administrador';
+    }
+
+    match /proyectos/{documentId} {
+      allow read, write: if isOwner(resource) || getUserRole() == 'administrador';
     }
   }
 }

--- a/src/pages/InsumosPage.jsx
+++ b/src/pages/InsumosPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { getInsumos, addInsumo, updateInsumo, deleteInsumo } from '../services/modules/insumosService';
+import { useAuth } from '../hooks/useAuth';
 import InsumoModal from '../components/InsumoModal';
 import InfoModal from '../components/InfoModal';
 import ConfirmDialog from '../components/ConfirmDialog';
@@ -30,18 +31,20 @@ function InsumosPage() {
   const [selectedInsumo, setSelectedInsumo] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deletingInsumoId, setDeletingInsumoId] = useState(null);
+  const { currentUser } = useAuth();
 
   const fetchInsumos = useCallback(async () => {
+    if (!currentUser) return;
     setLoading(true);
     try {
-      const data = await getInsumos();
+      const data = await getInsumos(currentUser.uid);
       setInsumos(data);
     } catch (error) {
       console.error("Error fetching supplies:", error);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [currentUser]);
 
   useEffect(() => {
     fetchInsumos();
@@ -58,11 +61,15 @@ function InsumosPage() {
   };
 
   const handleSaveInsumo = async (insumoData) => {
+    if (!currentUser) {
+      console.error("No user logged in");
+      return;
+    }
     try {
       if (editingInsumo) {
         await updateInsumo(editingInsumo.id, insumoData);
       } else {
-        await addInsumo(insumoData);
+        await addInsumo(insumoData, currentUser.uid);
       }
       handleCloseModal();
       fetchInsumos();

--- a/src/pages/ProveedoresPage.jsx
+++ b/src/pages/ProveedoresPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { getProveedores, addProveedor, updateProveedor, deleteProveedor } from '../services/modules/proveedoresService';
+import { useAuth } from '../hooks/useAuth';
 import ProveedorModal from '../components/ProveedorModal';
 import InfoModal from '../components/InfoModal';
 import ConfirmDialog from '../components/ConfirmDialog';
@@ -30,18 +31,20 @@ function ProveedoresPage() {
   const [selectedProveedor, setSelectedProveedor] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deletingProveedorId, setDeletingProveedorId] = useState(null);
+  const { currentUser } = useAuth();
 
   const fetchProveedores = useCallback(async () => {
+    if (!currentUser) return;
     setLoading(true);
     try {
-      const data = await getProveedores();
+      const data = await getProveedores(currentUser.uid);
       setProveedores(data);
     } catch (error) {
       console.error("Error fetching suppliers:", error);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [currentUser]);
 
   useEffect(() => {
     fetchProveedores();
@@ -58,11 +61,15 @@ function ProveedoresPage() {
   };
 
   const handleSaveProveedor = async (proveedorData) => {
+    if (!currentUser) {
+      console.error("No user logged in");
+      return;
+    }
     try {
       if (editingProveedor) {
         await updateProveedor(editingProveedor.id, proveedorData);
       } else {
-        await addProveedor(proveedorData);
+        await addProveedor(proveedorData, currentUser.uid);
       }
       handleCloseModal();
       fetchProveedores();

--- a/src/pages/ProyectosPage.jsx
+++ b/src/pages/ProyectosPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { getProyectos, addProyecto, updateProyecto, deleteProyecto } from '../services/modules/proyectosService';
+import { useAuth } from '../hooks/useAuth';
 import ProyectoModal from '../components/ProyectoModal';
 import InfoModal from '../components/InfoModal';
 import ConfirmDialog from '../components/ConfirmDialog';
@@ -30,18 +31,20 @@ function ProyectosPage() {
   const [selectedProyecto, setSelectedProyecto] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deletingProyectoId, setDeletingProyectoId] = useState(null);
+  const { currentUser } = useAuth();
 
   const fetchProyectos = useCallback(async () => {
+    if (!currentUser) return;
     setLoading(true);
     try {
-      const data = await getProyectos();
+      const data = await getProyectos(currentUser.uid);
       setProyectos(data);
     } catch (error) {
       console.error("Error fetching projects:", error);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [currentUser]);
 
   useEffect(() => {
     fetchProyectos();
@@ -58,11 +61,15 @@ function ProyectosPage() {
   };
 
   const handleSaveProyecto = async (proyectoData) => {
+    if (!currentUser) {
+      console.error("No user logged in");
+      return;
+    }
     try {
       if (editingProyecto) {
         await updateProyecto(editingProyecto.id, proyectoData);
       } else {
-        await addProyecto(proyectoData);
+        await addProyecto(proyectoData, currentUser.uid);
       }
       handleCloseModal();
       fetchProyectos();

--- a/src/services/modules/clientesService.js
+++ b/src/services/modules/clientesService.js
@@ -1,17 +1,19 @@
 import { db } from '../firebase';
-import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc, query, where } from 'firebase/firestore';
 
 const CLIENTES_COLLECTION = 'clientes';
 
-export const getClientes = async () => {
+export const getClientes = async (userId) => {
+  if (!userId) return [];
   const clientesCollection = collection(db, CLIENTES_COLLECTION);
-  const snapshot = await getDocs(clientesCollection);
+  const q = query(clientesCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 
-export const addCliente = async (clienteData) => {
+export const addCliente = async (clienteData, userId) => {
   const clientesCollection = collection(db, CLIENTES_COLLECTION);
-  const docRef = await addDoc(clientesCollection, clienteData);
+  const docRef = await addDoc(clientesCollection, { ...clienteData, userId });
   return docRef.id;
 };
 
@@ -25,8 +27,10 @@ export const deleteCliente = async (id) => {
   await deleteDoc(clienteDoc);
 };
 
-export const getClientesCount = async () => {
+export const getClientesCount = async (userId) => {
+  if (!userId) return 0;
   const clientesCollection = collection(db, CLIENTES_COLLECTION);
-  const snapshot = await getDocs(clientesCollection);
+  const q = query(clientesCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   return snapshot.size;
 };

--- a/src/services/modules/insumosService.js
+++ b/src/services/modules/insumosService.js
@@ -1,17 +1,19 @@
 import { db } from '../firebase';
-import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc, query, where } from 'firebase/firestore';
 
 const INSUMOS_COLLECTION = 'insumos';
 
-export const getInsumos = async () => {
+export const getInsumos = async (userId) => {
+  if (!userId) return [];
   const insumosCollection = collection(db, INSUMOS_COLLECTION);
-  const snapshot = await getDocs(insumosCollection);
+  const q = query(insumosCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 
-export const addInsumo = async (insumoData) => {
+export const addInsumo = async (insumoData, userId) => {
   const insumosCollection = collection(db, INSUMOS_COLLECTION);
-  const docRef = await addDoc(insumosCollection, insumoData);
+  const docRef = await addDoc(insumosCollection, { ...insumoData, userId });
   return docRef.id;
 };
 
@@ -25,8 +27,10 @@ export const deleteInsumo = async (id) => {
   await deleteDoc(insumoDoc);
 };
 
-export const getInsumosCount = async () => {
+export const getInsumosCount = async (userId) => {
+  if (!userId) return 0;
   const insumosCollection = collection(db, INSUMOS_COLLECTION);
-  const snapshot = await getDocs(insumosCollection);
+  const q = query(insumosCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   return snapshot.size;
 };

--- a/src/services/modules/productosService.js
+++ b/src/services/modules/productosService.js
@@ -1,17 +1,19 @@
 import { db } from '../firebase';
-import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc, query, where } from 'firebase/firestore';
 
 const PRODUCTOS_COLLECTION = 'productos';
 
-export const getProductos = async () => {
+export const getProductos = async (userId) => {
+  if (!userId) return [];
   const productosCollection = collection(db, PRODUCTOS_COLLECTION);
-  const snapshot = await getDocs(productosCollection);
+  const q = query(productosCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 
-export const addProducto = async (productoData) => {
+export const addProducto = async (productoData, userId) => {
   const productosCollection = collection(db, PRODUCTOS_COLLECTION);
-  const docRef = await addDoc(productosCollection, productoData);
+  const docRef = await addDoc(productosCollection, { ...productoData, userId });
   return docRef.id;
 };
 
@@ -25,8 +27,10 @@ export const deleteProducto = async (id) => {
   await deleteDoc(productoDoc);
 };
 
-export const getProductosCount = async () => {
+export const getProductosCount = async (userId) => {
+  if (!userId) return 0;
   const productosCollection = collection(db, PRODUCTOS_COLLECTION);
-  const snapshot = await getDocs(productosCollection);
+  const q = query(productosCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   return snapshot.size;
 };

--- a/src/services/modules/proveedoresService.js
+++ b/src/services/modules/proveedoresService.js
@@ -1,12 +1,14 @@
 import { db } from '../firebase';
-import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc, query, where } from 'firebase/firestore';
 
 const PROVEEDORES_COLLECTION = 'proveedores';
 
 // Function to get all suppliers
-export const getProveedores = async () => {
+export const getProveedores = async (userId) => {
+  if (!userId) return [];
   const proveedoresCollection = collection(db, PROVEEDORES_COLLECTION);
-  const snapshot = await getDocs(proveedoresCollection);
+  const q = query(proveedoresCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   const proveedoresList = snapshot.docs.map(doc => ({
     id: doc.id,
     ...doc.data()
@@ -15,9 +17,9 @@ export const getProveedores = async () => {
 };
 
 // Function to add a new supplier
-export const addProveedor = async (proveedorData) => {
+export const addProveedor = async (proveedorData, userId) => {
   const proveedoresCollection = collection(db, PROVEEDORES_COLLECTION);
-  const docRef = await addDoc(proveedoresCollection, proveedorData);
+  const docRef = await addDoc(proveedoresCollection, { ...proveedorData, userId });
   return docRef.id;
 };
 
@@ -33,8 +35,10 @@ export const deleteProveedor = async (id) => {
   await deleteDoc(proveedorDoc);
 };
 
-export const getProveedoresCount = async () => {
+export const getProveedoresCount = async (userId) => {
+  if (!userId) return 0;
   const proveedoresCollection = collection(db, PROVEEDORES_COLLECTION);
-  const snapshot = await getDocs(proveedoresCollection);
+  const q = query(proveedoresCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   return snapshot.size;
 };

--- a/src/services/modules/proyectosService.js
+++ b/src/services/modules/proyectosService.js
@@ -1,17 +1,19 @@
 import { db } from '../firebase';
-import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc, query, where } from 'firebase/firestore';
 
 const PROYECTOS_COLLECTION = 'proyectos';
 
-export const getProyectos = async () => {
+export const getProyectos = async (userId) => {
+  if (!userId) return [];
   const proyectosCollection = collection(db, PROYECTOS_COLLECTION);
-  const snapshot = await getDocs(proyectosCollection);
+  const q = query(proyectosCollection, where("userId", "==", userId));
+  const snapshot = await getDocs(q);
   return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 
-export const addProyecto = async (proyectoData) => {
+export const addProyecto = async (proyectoData, userId) => {
   const proyectosCollection = collection(db, PROYECTOS_COLLECTION);
-  const docRef = await addDoc(proyectosCollection, proyectoData);
+  const docRef = await addDoc(proyectosCollection, { ...proyectoData, userId });
   return docRef.id;
 };
 


### PR DESCRIPTION
This commit enhances the Firestore security rules to ensure that users can only read and write their own data.

Previously, the rules were too permissive, allowing any authenticated user to read all data, and any editor or administrator to write to any document.

The changes in this commit include:
- Modifying the application code to add a `userId` field to each document in the `clientes`, `insumos`, `productos`, `proveedores`, and `proyectos` collections when they are created.
- Updating the data access services to query only the data belonging to the currently authenticated user.
- Replacing the old security rules with new, more restrictive rules that enforce user ownership of data. Now, users can only access documents that have their `userId`. Administrators retain full access.