### PR TITLE
feat: Reforzar reglas de Firestore y añadir página de usuarios

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,25 +3,48 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Función para obtener los datos del rol del usuario que hace la petición.
     function getUserRole() {
       return get(/databases/$(database)/documents/usuarios/$(request.auth.uid)).data.role;
     }
 
-    // Reglas para la colección de Usuarios
-    // Solo los administradores pueden leer la lista completa y modificar roles.
-    // Cada usuario puede leer su propio documento de rol.
-    match /usuarios/{userId} {
-      allow read: if request.auth.uid == userId || getUserRole() == 'administrador';
-      allow write: if getUserRole() == 'administrador';
+    function isAdmin() {
+      let adminUIDs = ['7M6XuPSQf0UHUvet5KnEISxiYBT2', 'NIFudxxXnea8HqFzeMpxY0kma5b2'];
+      return request.auth.uid in adminUIDs || getUserRole() == 'administrador';
     }
 
-    // Reglas para TODAS las demás colecciones de datos (productos, clientes, etc.)
-    // La lectura está permitida para cualquier usuario autenticado.
-    // La escritura (crear, actualizar, borrar) solo para editores y administradores.
-    match /{document=**} {
-      allow read: if request.auth != null;
-      allow write: if getUserRole() in ['editor', 'administrador'] || request.auth.uid == 'NIFudxxXnea8HqFzeMpxY0kma5b2';
+    // Reglas para la colección de Usuarios
+    // Los administradores pueden leer y escribir cualquier documento de usuario.
+    // Cada usuario puede leer su propio documento.
+    match /usuarios/{userId} {
+      allow read: if request.auth.uid == userId || isAdmin();
+      allow write: if isAdmin();
+    }
+
+    // Reglas para colecciones específicas.
+    // Solo el creador del documento o un administrador puede leer o escribir.
+    // Asume que cada documento tiene un campo 'createdBy' con el UID del creador.
+    match /clientes/{clienteId} {
+      allow read, write: if request.resource.data.createdBy == request.auth.uid || isAdmin();
+    }
+
+    match /insumos/{insumoId} {
+      allow read, write: if request.resource.data.createdBy == request.auth.uid || isAdmin();
+    }
+
+    match /productos/{productoId} {
+      allow read, write: if request.resource.data.createdBy == request.auth.uid || isAdmin();
+    }
+
+    match /proveedores/{proveedorId} {
+      allow read, write: if request.resource.data.createdBy == request.auth.uid || isAdmin();
+    }
+
+    match /proyectos/{proyectoId} {
+      allow read, write: if request.resource.data.createdBy == request.auth.uid || isAdmin();
+    }
+
+    match /sinoptico/{sinopticoId} {
+      allow read, write: if request.resource.data.createdBy == request.auth.uid || isAdmin();
     }
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ const InsumosPage = lazy(() => import('./pages/InsumosPage'));
 const ProyectosPage = lazy(() => import('./pages/ProyectosPage'));
 const SinopticoPage = lazy(() => import('./pages/SinopticoPage'));
 const VerifyEmailPage = lazy(() => import('./pages/VerifyEmailPage'));
+const UsuariosPage = lazy(() => import('./pages/UsuariosPage'));
 
 function AppContent() {
   const { loading } = useAuth();
@@ -47,6 +48,14 @@ function AppContent() {
           <Route path="insumos" element={<InsumosPage />} />
           <Route path="proyectos" element={<ProyectosPage />} />
           <Route path="sinoptico" element={<SinopticoPage />} />
+          <Route
+            path="usuarios"
+            element={
+              <ProtectedRoute adminOnly={true}>
+                <UsuariosPage />
+              </ProtectedRoute>
+            }
+          />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,4 +1,4 @@
-import React, { useState, Fragment } from 'react';
+import React, { useState, Fragment, useMemo } from 'react';
 import { Outlet, useNavigate, Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import {
@@ -12,6 +12,7 @@ import {
   UserCircleIcon,
   TruckIcon,
   BriefcaseIcon,
+  UserGroupIcon,
 } from '@heroicons/react/24/outline';
 import { Transition } from '@headlessui/react';
 
@@ -23,6 +24,7 @@ const navItems = [
   { text: 'Productos', path: '/productos', icon: ShoppingCartIcon },
   { text: 'Insumos', path: '/insumos', icon: ArchiveBoxIcon },
   { text: 'Sinóptico', path: '/sinoptico', icon: ChartBarIcon },
+  { text: 'Usuarios', path: '/usuarios', icon: UserGroupIcon, adminOnly: true },
 ];
 
 function Layout() {
@@ -40,6 +42,13 @@ function Layout() {
     }
   };
 
+  const visibleNavItems = useMemo(() => {
+    if (currentUser?.role === 'administrador') {
+      return navItems;
+    }
+    return navItems.filter(item => !item.adminOnly);
+  }, [currentUser]);
+
   return (
     <div className="flex h-screen bg-gray-50">
       {/* Sidebar */}
@@ -49,7 +58,7 @@ function Layout() {
         </div>
         <div className="flex flex-col flex-1 overflow-y-auto">
           <nav className="flex-1 px-4 py-4">
-            {navItems.map((item) => (
+            {visibleNavItems.map((item) => (
               <Link
                 key={item.text}
                 to={item.path}

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,26 +1,28 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
-function ProtectedRoute({ children }) {
+function ProtectedRoute({ children, adminOnly = false }) {
   const { currentUser, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
-    // You can add a spinner here if you want
-    return <div>Loading...</div>;
+    return <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>Loading...</div>;
   }
 
   if (!currentUser) {
-    // User not logged in, redirect to login page
-    return <Navigate to="/login" />;
+    return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   if (!currentUser.emailVerified) {
-    // User's email is not verified, redirect to verification page
-    return <Navigate to="/verify-email" />;
+    return <Navigate to="/verify-email" replace />;
   }
 
-  // User is logged in and email is verified, render the child components
+  if (adminOnly && currentUser.role !== 'administrador') {
+    // Redirect non-admins from admin-only routes
+    return <Navigate to="/" replace />;
+  }
+
   return children;
 }
 

--- a/src/components/UsuarioModal.jsx
+++ b/src/components/UsuarioModal.jsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect, Fragment, forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import { Dialog, Transition } from '@headlessui/react';
+
+const UsuarioModal = forwardRef(({ open, onClose, onSave, usuario }, ref) => {
+  const [formData, setFormData] = useState({
+    role: '',
+  });
+
+  useEffect(() => {
+    if (usuario) {
+      setFormData({
+        role: usuario.role || 'lector',
+      });
+    } else {
+      setFormData({
+        role: 'lector',
+      });
+    }
+  }, [usuario, open]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSave = () => {
+    onSave(formData);
+  };
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel ref={ref} className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+                <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                  <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">
+                    Editar Usuario
+                  </Dialog.Title>
+                  <div className="mt-2">
+                    <p className="text-sm text-gray-500 mb-4">
+                      Modificar el rol del usuario.
+                    </p>
+                    <div className="space-y-4">
+                      <div>
+                        <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                          Email
+                        </label>
+                        <input
+                          type="email"
+                          name="email"
+                          id="email"
+                          value={usuario?.email || ''}
+                          readOnly
+                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm bg-gray-100"
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="role" className="block text-sm font-medium text-gray-700">
+                          Rol
+                        </label>
+                        <select
+                          name="role"
+                          id="role"
+                          value={formData.role}
+                          onChange={handleChange}
+                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                        >
+                          <option value="lector">Lector</option>
+                          <option value="editor">Editor</option>
+                          <option value="administrador">Administrador</option>
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                  <button
+                    type="button"
+                    className="inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:ml-3 sm:w-auto sm:text-sm"
+                    onClick={handleSave}
+                  >
+                    Guardar
+                  </button>
+                  <button
+                    type="button"
+                    className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-indigo-500 focus:ring-offset-2 sm:mt-0 sm:w-auto sm:text-sm"
+                    onClick={onClose}
+                  >
+                    Cancelar
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+});
+
+UsuarioModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  usuario: PropTypes.object,
+};
+
+UsuarioModal.displayName = 'UsuarioModal';
+
+export default UsuarioModal;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import {
   auth,
+  db,
+  doc,
+  getDoc,
   onAuthStateChanged,
   signInWithEmailAndPassword,
   signOut as firebaseSignOut,
@@ -60,8 +63,18 @@ export function AuthProvider({ children }) {
 
   // Effect to listen for auth state changes
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, user => {
-      setCurrentUser(user);
+    const unsubscribe = onAuthStateChanged(auth, async user => {
+      if (user) {
+        const userDocRef = doc(db, 'usuarios', user.uid);
+        const userDoc = await getDoc(userDocRef);
+        if (userDoc.exists()) {
+          setCurrentUser({ ...user, ...userDoc.data() });
+        } else {
+          setCurrentUser(user);
+        }
+      } else {
+        setCurrentUser(null);
+      }
       setLoading(false);
     });
 

--- a/src/pages/UsuariosPage.jsx
+++ b/src/pages/UsuariosPage.jsx
@@ -1,0 +1,146 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { getUsuarios, updateUsuario, deleteUsuario } from '../services/modules/usuariosService';
+import UsuarioModal from '../components/UsuarioModal';
+import ConfirmDialog from '../components/ConfirmDialog';
+import DataGrid from '../components/DataGrid';
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { Transition } from '@headlessui/react';
+
+const ActionsCellRenderer = ({ data, onEdit, onDelete }) => (
+  <div className="flex items-center justify-end space-x-2">
+    <button data-testid="edit-button" onClick={() => onEdit(data)} className="text-indigo-600 hover:text-indigo-900 transition-colors duration-200">
+      <PencilIcon className="h-5 w-5" />
+    </button>
+    <button data-testid="delete-button" onClick={() => onDelete(data.id)} className="text-red-600 hover:text-red-900 transition-colors duration-200">
+      <TrashIcon className="h-5 w-5" />
+    </button>
+  </div>
+);
+
+function UsuariosPage() {
+  const [usuarios, setUsuarios] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingUsuario, setEditingUsuario] = useState(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deletingUsuarioId, setDeletingUsuarioId] = useState(null);
+
+  const fetchUsuarios = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getUsuarios();
+      setUsuarios(data);
+    } catch (error) {
+      console.error("Error fetching users:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUsuarios();
+  }, [fetchUsuarios]);
+
+  const handleOpenModal = (usuario = null) => {
+    setEditingUsuario(usuario);
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setEditingUsuario(null);
+  };
+
+  const handleSaveUsuario = async (usuarioData) => {
+    try {
+      if (editingUsuario) {
+        await updateUsuario(editingUsuario.id, usuarioData);
+      }
+      handleCloseModal();
+      fetchUsuarios();
+    } catch (error) {
+      console.error("Error saving user:", error);
+    }
+  };
+
+  const handleDeleteClick = (id) => {
+    setDeletingUsuarioId(id);
+    setConfirmOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    try {
+      await deleteUsuario(deletingUsuarioId);
+      setConfirmOpen(false);
+      setDeletingUsuarioId(null);
+      fetchUsuarios();
+    } catch (error) {
+      console.error("Error deleting user:", error);
+    }
+  };
+
+  const columnDefs = useMemo(() => [
+    { headerName: "Email", field: "email", flex: 2, sortable: true, filter: true },
+    { headerName: "Rol", field: "role", flex: 1, sortable: true, filter: true },
+    {
+      headerName: "Acciones",
+      cellRenderer: 'actionsCellRenderer',
+      cellRendererParams: {
+        onEdit: handleOpenModal,
+        onDelete: handleDeleteClick,
+      },
+      flex: 0.5,
+      sortable: false,
+      filter: false,
+      resizable: false,
+      pinned: 'right',
+    }
+  ], []);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold text-gray-800">Usuarios</h1>
+      </div>
+
+      <div className="flex-grow bg-white shadow-lg rounded-lg overflow-hidden">
+        <DataGrid
+          rowData={usuarios}
+          columnDefs={columnDefs}
+          loading={loading}
+          components={{
+            actionsCellRenderer: ActionsCellRenderer,
+          }}
+        />
+      </div>
+
+      <Transition
+        show={modalOpen}
+        as={React.Fragment}
+        enter="transition-opacity duration-300"
+        enterFrom="opacity-0"
+        enterTo="opacity-100"
+        leave="transition-opacity duration-300"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+      >
+        <UsuarioModal
+          open={modalOpen}
+          onClose={handleCloseModal}
+          onSave={handleSaveUsuario}
+          usuario={editingUsuario}
+        />
+      </Transition>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        title="Confirmar Eliminación"
+        message="¿Estás seguro de que quieres eliminar este usuario? Esta acción no se puede deshacer."
+      />
+    </div>
+  );
+}
+
+export default UsuariosPage;

--- a/src/services/modules/usuariosService.js
+++ b/src/services/modules/usuariosService.js
@@ -1,0 +1,41 @@
+import {
+  db,
+  collection,
+  getDocs,
+  updateDoc,
+  deleteDoc,
+  doc
+} from '../firebase';
+
+const USUARIOS_COLLECTION = 'usuarios';
+
+export const getUsuarios = async () => {
+  try {
+    const usuariosCollection = collection(db, USUARIOS_COLLECTION);
+    const snapshot = await getDocs(usuariosCollection);
+    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+  } catch (error) {
+    console.error("Error al obtener usuarios:", error);
+    throw new Error("No se pudieron obtener los usuarios. Por favor, intente de nuevo más tarde.");
+  }
+};
+
+export const updateUsuario = async (id, usuarioData) => {
+  try {
+    const usuarioDoc = doc(db, USUARIOS_COLLECTION, id);
+    await updateDoc(usuarioDoc, usuarioData);
+  } catch (error) {
+    console.error("Error al actualizar usuario:", error);
+    throw new Error("No se pudo actualizar el usuario. Por favor, intente de nuevo más tarde.");
+  }
+};
+
+export const deleteUsuario = async (id) => {
+  try {
+    const usuarioDoc = doc(db, USUARIOS_COLLECTION, id);
+    await deleteDoc(usuarioDoc);
+  } catch (error) {
+    console.error("Error al eliminar usuario:", error);
+    throw new Error("No se pudo eliminar el usuario. Por favor, intente de nuevo más tarde.");
+  }
+};

--- a/vite.config.js.timestamp-1755288600179-a596ba025cca2.mjs
+++ b/vite.config.js.timestamp-1755288600179-a596ba025cca2.mjs
@@ -1,0 +1,27 @@
+// vite.config.js
+import { defineConfig } from "file:///app/node_modules/vite/dist/node/index.js";
+import react from "file:///app/node_modules/@vitejs/plugin-react/dist/index.js";
+import tailwindcss from "file:///app/node_modules/@tailwindcss/vite/dist/index.mjs";
+var vite_config_default = defineConfig({
+  plugins: [react(), tailwindcss()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules")) {
+            return "vendor";
+          }
+        }
+      }
+    }
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.js"
+  }
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcuanMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvYXBwXCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ZpbGVuYW1lID0gXCIvYXBwL3ZpdGUuY29uZmlnLmpzXCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ltcG9ydF9tZXRhX3VybCA9IFwiZmlsZTovLy9hcHAvdml0ZS5jb25maWcuanNcIjsvLy8gPHJlZmVyZW5jZSB0eXBlcz1cInZpdGVzdFwiIC8+XG5pbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd2aXRlJ1xuaW1wb3J0IHJlYWN0IGZyb20gJ0B2aXRlanMvcGx1Z2luLXJlYWN0J1xuaW1wb3J0IHRhaWx3aW5kY3NzIGZyb20gJ0B0YWlsd2luZGNzcy92aXRlJ1xuXG4vLyBodHRwczovL3ZpdGUuZGV2L2NvbmZpZy9cbmV4cG9ydCBkZWZhdWx0IGRlZmluZUNvbmZpZyh7XG4gIHBsdWdpbnM6IFtyZWFjdCgpLCB0YWlsd2luZGNzcygpXSxcbiAgYnVpbGQ6IHtcbiAgICByb2xsdXBPcHRpb25zOiB7XG4gICAgICBvdXRwdXQ6IHtcbiAgICAgICAgbWFudWFsQ2h1bmtzKGlkKSB7XG4gICAgICAgICAgaWYgKGlkLmluY2x1ZGVzKCdub2RlX21vZHVsZXMnKSkge1xuICAgICAgICAgICAgcmV0dXJuICd2ZW5kb3InO1xuICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgfVxuICAgIH1cbiAgfSxcbiAgdGVzdDoge1xuICAgIGdsb2JhbHM6IHRydWUsXG4gICAgZW52aXJvbm1lbnQ6ICdqc2RvbScsXG4gICAgc2V0dXBGaWxlczogJy4vc3JjL3NldHVwVGVzdHMuanMnLFxuICB9LFxufSlcbiJdLAogICJtYXBwaW5ncyI6ICI7QUFDQSxTQUFTLG9CQUFvQjtBQUM3QixPQUFPLFdBQVc7QUFDbEIsT0FBTyxpQkFBaUI7QUFHeEIsSUFBTyxzQkFBUSxhQUFhO0FBQUEsRUFDMUIsU0FBUyxDQUFDLE1BQU0sR0FBRyxZQUFZLENBQUM7QUFBQSxFQUNoQyxPQUFPO0FBQUEsSUFDTCxlQUFlO0FBQUEsTUFDYixRQUFRO0FBQUEsUUFDTixhQUFhLElBQUk7QUFDZixjQUFJLEdBQUcsU0FBUyxjQUFjLEdBQUc7QUFDL0IsbUJBQU87QUFBQSxVQUNUO0FBQUEsUUFDRjtBQUFBLE1BQ0Y7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQUFBLEVBQ0EsTUFBTTtBQUFBLElBQ0osU0FBUztBQUFBLElBQ1QsYUFBYTtBQUFBLElBQ2IsWUFBWTtBQUFBLEVBQ2Q7QUFDRixDQUFDOyIsCiAgIm5hbWVzIjogW10KfQo=


### PR DESCRIPTION
Este commit introduce dos cambios principales:

1.  **Refuerzo de las reglas de seguridad de Firestore:**
    - Se han actualizado las reglas de `firestore.rules` para ser más restrictivas.
    - Ahora, los usuarios solo pueden leer y escribir los datos de los que son propietarios (basado en un campo `createdBy`).
    - Se ha introducido una función `isAdmin()` que otorga acceso completo a los administradores, incluyendo los dos UIDs especificados.

2.  **Creación de una página de gestión de usuarios:**
    - Se ha añadido una nueva página `/usuarios` para que los administradores puedan gestionar los roles de los usuarios.
    - Se ha creado un nuevo servicio (`usuariosService.js`), un modal (`UsuarioModal.jsx`) y el componente de la página (`UsuariosPage.jsx`).
    - Se ha actualizado la navegación para que el enlace a la página de usuarios solo sea visible para los administradores.
    - Se ha protegido la ruta `/usuarios` para que solo los administradores puedan acceder a ella.
    - Se ha modificado el `AuthContext` para que el rol del usuario esté disponible en toda la aplicación.