### PR TITLE
feat: Add ag-grid-enterprise for row grouping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@heroicons/react": "^2.1.3",
         "@tailwindcss/vite": "^4.1.12",
         "ag-grid-community": "^31.3.2",
+        "ag-grid-enterprise": "^34.1.1",
         "firebase": "^12.1.0",
         "prop-types": "^15.8.1",
         "react": "^19.1.1",
@@ -3027,6 +3028,60 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ag-charts-community": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-community/-/ag-charts-community-12.1.1.tgz",
+      "integrity": "sha512-5RfYXwqUr4yR1KIQAPvCsF9uaNRV6Ghs6Bj9tMn5bHL0xf1EOncEpkzXZjIXpM4yGxYk8UJKRTI3mByPjYRe8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ag-charts-core": "12.1.1",
+        "ag-charts-locale": "12.1.1",
+        "ag-charts-types": "12.1.1"
+      }
+    },
+    "node_modules/ag-charts-community/node_modules/ag-charts-types": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-12.1.1.tgz",
+      "integrity": "sha512-VbAOfp1E7+Z/TBufJOIjUYdx70kQRDg49WoluiVKVSB0r0el/uvxARp9xjzx4ByBq9+Xq/V23tJVsRj1MS2A/g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ag-charts-core": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-core/-/ag-charts-core-12.1.1.tgz",
+      "integrity": "sha512-Kp/fXAtNmHWWo4MTHfYN1O4O5F3wWF5ZhLcjbfrdBcx3rBdbQGw46K/FcclK8Wyer3tmITBG9EZQFO/CDeu4vA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ag-charts-types": "12.1.1"
+      }
+    },
+    "node_modules/ag-charts-core/node_modules/ag-charts-types": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-12.1.1.tgz",
+      "integrity": "sha512-VbAOfp1E7+Z/TBufJOIjUYdx70kQRDg49WoluiVKVSB0r0el/uvxARp9xjzx4ByBq9+Xq/V23tJVsRj1MS2A/g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ag-charts-enterprise": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-enterprise/-/ag-charts-enterprise-12.1.1.tgz",
+      "integrity": "sha512-kcifzWM1JA+gmXKUcHrFb5P23MAnY+3lyBo9MVziZh0RMH/fHa7wEjgPHyim7/71Lbz9DmJbaYaPwXpLp/4f9Q==",
+      "license": "Commercial",
+      "optional": true,
+      "dependencies": {
+        "ag-charts-community": "12.1.1",
+        "ag-charts-core": "12.1.1"
+      }
+    },
+    "node_modules/ag-charts-locale": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-locale/-/ag-charts-locale-12.1.1.tgz",
+      "integrity": "sha512-kpmtZvC12idQcNPnM3BIALmFUXvbb2TtCZtTuXqWdmtT7ykgnQCWWFczLOcM4EsgfnaudATI952JLAeQ/C2wwQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/ag-charts-types": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-10.3.1.tgz",
@@ -3038,6 +3093,34 @@
       "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.2.tgz",
       "integrity": "sha512-GxqFRD0OcjaVRE1gwLgoP0oERNPH8Lk8wKJ1txulsxysEQ5dZWHhiIoXXSiHjvOCVMkK/F5qzY6HNrn6VeDMTQ==",
       "license": "MIT"
+    },
+    "node_modules/ag-grid-enterprise": {
+      "version": "34.1.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-enterprise/-/ag-grid-enterprise-34.1.1.tgz",
+      "integrity": "sha512-r/HPmKM7rU+EnMYjzUUnp7Zlq+C77chUCdcT9oTS4eYPbjS/TF4bZO8laL4Nx/eAnwN5G5tyltIqUnSHpJmqKw==",
+      "license": "Commercial",
+      "dependencies": {
+        "ag-grid-community": "34.1.1"
+      },
+      "optionalDependencies": {
+        "ag-charts-community": "12.1.1",
+        "ag-charts-enterprise": "12.1.1"
+      }
+    },
+    "node_modules/ag-grid-enterprise/node_modules/ag-charts-types": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ag-charts-types/-/ag-charts-types-12.1.1.tgz",
+      "integrity": "sha512-VbAOfp1E7+Z/TBufJOIjUYdx70kQRDg49WoluiVKVSB0r0el/uvxARp9xjzx4ByBq9+Xq/V23tJVsRj1MS2A/g==",
+      "license": "MIT"
+    },
+    "node_modules/ag-grid-enterprise/node_modules/ag-grid-community": {
+      "version": "34.1.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-34.1.1.tgz",
+      "integrity": "sha512-ODVvGoMTkyGvMT8b5lzvum5r93bG6CKdJdNrk6u/aYS7oqZ5rUEXJJHC8n8Zq+o76KhFiXMBQrU39xuhz8i+Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "ag-charts-types": "12.1.1"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@heroicons/react": "^2.1.3",
     "@tailwindcss/vite": "^4.1.12",
     "ag-grid-community": "^31.3.2",
+    "ag-grid-enterprise": "^34.1.1",
     "firebase": "^12.1.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.1",


### PR DESCRIPTION
This change adds the `ag-grid-enterprise` package to enable row grouping functionality.

The originally requested package, `@ag-grid-community/row-grouping`, does not exist, as row grouping is an enterprise feature.

The `SinopticoPage.jsx` file already contained the necessary code to import and register the `RowGroupingModule`, so no changes were made to it.