### PR TITLE
fix: Correct import path for RowGroupingModule

### DIFF
--- a/src/pages/SinopticoPage.jsx
+++ b/src/pages/SinopticoPage.jsx
@@ -15,7 +15,7 @@ import { PlusIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
 // AG Grid Module Registration
 import { ModuleRegistry } from '@ag-grid-community/core';
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
-import { RowGroupingModule } from '@ag-grid-community/row-grouping';
+import { RowGroupingModule } from 'ag-grid-enterprise';
 import 'ag-grid-community/styles/ag-theme-balham.css';
 
 ModuleRegistry.registerModules([


### PR DESCRIPTION
This change corrects the import path for `RowGroupingModule` in `src/pages/SinopticoPage.jsx` to `ag-grid-enterprise`. This resolves the build error caused by the incorrect import path.