### PR TITLE
fix: Export getDoc from firebase.js

### DIFF
--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -17,6 +17,7 @@ import {
   getFirestore,
   collection,
   getDocs,
+  getDoc,
   addDoc,
   updateDoc,
   deleteDoc,
@@ -54,6 +55,7 @@ export {
   // Firestore functions
   collection,
   getDocs,
+  getDoc,
   addDoc,
   updateDoc,
   deleteDoc,


### PR DESCRIPTION
This change adds the `getDoc` function to the import and export lists in `src/services/firebase.js`. This resolves a build error caused by `AuthContext.jsx` trying to import a non-exported function.