### PR TITLE
feat: Implement in-situ editing for Sinoptico nodes

### DIFF
--- a/src/hooks/useQuickUpdate.js
+++ b/src/hooks/useQuickUpdate.js
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { updateSinopticoItem } from '../services/modules/sinopticoItemsService';
+
+/**
+ * Custom hook for performing a quick, single-field update on a sinoptico item.
+ *
+ * @returns {{updateField: Function, loading: boolean, error: Error|null}}
+ */
+export const useQuickUpdate = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  /**
+   * Updates a single field for a given sinoptico item.
+   * @param {string} id - The ID of the document to update.
+   * @param {string} field - The name of the field to update.
+   * @param {any} value - The new value for the field.
+   * @returns {Promise<boolean>} - True if successful, false otherwise.
+   */
+  const updateField = async (id, field, value) => {
+    setLoading(true);
+    setError(null);
+    try {
+      await updateSinopticoItem(id, { [field]: value });
+      setLoading(false);
+      return true;
+    } catch (err) {
+      console.error("Error updating field:", err);
+      setError(err);
+      setLoading(false);
+      return false;
+    }
+  };
+
+  return { updateField, loading, error };
+};

--- a/src/pages/SinopticoPage.jsx
+++ b/src/pages/SinopticoPage.jsx
@@ -175,6 +175,7 @@ const SinopticoPage = () => {
                       level={0}
                       editMode={editMode}
                       onEdit={handleOpenModal}
+                      onUpdateComplete={fetchHierarchy}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
- Adds a new custom hook `useQuickUpdate` to handle single-field updates for sinoptico items, encapsulating the API call and loading/error states.
- Modifies the `SinopticoNode` component to allow in-place editing of the 'nombre' (name) and 'codigo' (code) fields.
- Users can now double-click on these fields to turn them into editable inputs.
- Changes are saved automatically on blur or by pressing Enter.
- The data is refreshed after each successful update to reflect the changes in the UI.