### PR TITLE
feat: Implement change history (audit log) for items

### DIFF
--- a/src/components/AuditLogModal.jsx
+++ b/src/components/AuditLogModal.jsx
@@ -1,0 +1,104 @@
+import React, { Fragment, useState, useEffect } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { getAuditLogsForItem } from '../services/modules/sinopticoItemsService';
+import GridSkeletonLoader from './GridSkeletonLoader';
+
+const AuditLogModal = ({ isOpen, onClose, itemId }) => {
+  const [logs, setLogs] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (isOpen && itemId) {
+      const fetchLogs = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+          const fetchedLogs = await getAuditLogsForItem(itemId);
+          setLogs(fetchedLogs);
+        } catch (err) {
+          setError('Error al cargar el historial de cambios.');
+          console.error(err);
+        } finally {
+          setLoading(false);
+        }
+      };
+      fetchLogs();
+    }
+  }, [isOpen, itemId]);
+
+  const renderChangeDetails = (log) => {
+    if (log.action === 'create' && log.createdData) {
+      return <pre className="text-xs bg-gray-100 p-2 rounded mt-1">{JSON.stringify(log.createdData, null, 2)}</pre>;
+    }
+    if (log.action === 'update' && log.changes) {
+       return (
+        <ul className="text-xs list-disc pl-5 mt-1">
+          {Object.entries(log.changes).map(([key, value]) => (
+            <li key={key}>
+              <strong className="font-semibold">{key}:</strong> de <em className="text-red-600">{JSON.stringify(value.from)}</em> a <em className="text-green-600">{JSON.stringify(value.to)}</em>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+    return <p className="text-xs text-gray-500">No hay detalles adicionales.</p>;
+  };
+
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-20" onClose={onClose}>
+        <Transition.Child as={Fragment} {...}>
+          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-20 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child as={Fragment} {...}>
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-2xl">
+                <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                  <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">
+                    Historial de Cambios
+                  </Dialog.Title>
+                  <div className="mt-4" style={{ minHeight: '300px' }}>
+                    {loading && <GridSkeletonLoader count={3} />}
+                    {error && <p className="text-red-500">{error}</p>}
+                    {!loading && !error && logs.length === 0 && (
+                      <p>No se encontraron registros de auditoría para este item.</p>
+                    )}
+                    {!loading && !error && logs.length > 0 && (
+                      <div className="space-y-4">
+                        {logs.map(log => (
+                          <div key={log.id} className="p-3 bg-gray-50 rounded-md border border-gray-200">
+                            <p className="text-sm font-medium text-gray-800">
+                              <span className="font-bold capitalize">{log.action}</span> por <span className="text-blue-600">{log.userEmail}</span>
+                            </p>
+                            <p className="text-xs text-gray-500 mb-1">
+                              {log.timestamp?.toDate().toLocaleString() || 'Fecha no disponible'}
+                            </p>
+                            {renderChangeDetails(log)}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                  <button
+                    type="button"
+                    className="mt-3 inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none sm:mt-0 sm:w-auto sm:text-sm"
+                    onClick={onClose}
+                  >
+                    Cerrar
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+};
+
+export default AuditLogModal;

--- a/src/pages/SinopticoNode.jsx
+++ b/src/pages/SinopticoNode.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { ChevronRightIcon, ChevronDownIcon, PencilIcon, PlusCircleIcon } from '@heroicons/react/24/solid';
+import { ChevronRightIcon, ChevronDownIcon, PencilIcon, PlusCircleIcon, ClockIcon } from '@heroicons/react/24/solid';
 import { useQuickUpdate } from '../hooks/useQuickUpdate';
 
-const SinopticoNode = ({ node, level, editMode, onEdit, onUpdateComplete }) => {
+const SinopticoNode = ({ node, level, editMode, onEdit, onUpdateComplete, onOpenAuditLog }) => {
   const [isOpen, setIsOpen] = useState(true);
   const [editingField, setEditingField] = useState(null); // 'nombre', 'codigo', or null
   const [editValue, setEditValue] = useState('');
@@ -108,6 +108,9 @@ const SinopticoNode = ({ node, level, editMode, onEdit, onUpdateComplete }) => {
         <div className="text-gray-600">{node.medidas || 'N/A'}</div>
         {editMode && (
           <div className="flex items-center space-x-2">
+            <button onClick={() => onOpenAuditLog(node.id)} className="text-gray-600 hover:text-gray-800" title="Ver Historial">
+              <ClockIcon className="h-5 w-5" />
+            </button>
             <button onClick={() => onEdit(node)} className="text-blue-600 hover:text-blue-800" title="Editar Item Completo">
               <PencilIcon className="h-5 w-5" />
             </button>
@@ -133,6 +136,7 @@ const SinopticoNode = ({ node, level, editMode, onEdit, onUpdateComplete }) => {
               editMode={editMode}
               onEdit={onEdit}
               onUpdateComplete={onUpdateComplete}
+              onOpenAuditLog={onOpenAuditLog}
             />
           ))}
         </div>

--- a/src/services/modules/sinopticoItemsService.js
+++ b/src/services/modules/sinopticoItemsService.js
@@ -5,11 +5,41 @@ import {
   addDoc,
   updateDoc,
   deleteDoc,
-  doc
+  doc,
+  serverTimestamp,
+  query,
+  where,
+  orderBy,
+  getDoc
 } from '../firebase';
+import { auth } from '../firebase';
 
-// All synoptic items will be stored in the 'productos' collection for now.
 const SINOPTICO_ITEMS_COLLECTION = 'productos';
+const AUDIT_LOGS_COLLECTION = 'audit_logs';
+
+const logAuditEvent = async (action, itemId, details = {}) => {
+  const user = auth.currentUser;
+  if (!user) {
+    console.error("No authenticated user found for audit logging.");
+    return;
+  }
+
+  const auditLogData = {
+    action,
+    itemId,
+    userId: user.uid,
+    userEmail: user.email,
+    timestamp: serverTimestamp(),
+    ...details,
+  };
+
+  try {
+    const logsCollection = collection(db, AUDIT_LOGS_COLLECTION);
+    await addDoc(logsCollection, auditLogData);
+  } catch (error) {
+    console.error("Failed to write audit log:", error);
+  }
+};
 
 export const getSinopticoItems = async () => {
   const itemsCollection = collection(db, SINOPTICO_ITEMS_COLLECTION);
@@ -19,19 +49,68 @@ export const getSinopticoItems = async () => {
 
 export const addSinopticoItem = async (itemData) => {
   const itemsCollection = collection(db, SINOPTICO_ITEMS_COLLECTION);
-  // The itemData should be pre-populated with type, parentId, etc.
-  const docRef = await addDoc(itemsCollection, itemData);
+  const user = auth.currentUser;
+  const dataWithMeta = {
+    ...itemData,
+    createdBy: user?.email,
+    createdAt: serverTimestamp(),
+    lastModifiedBy: user?.email,
+    lastModifiedAt: serverTimestamp(),
+  };
+
+  const docRef = await addDoc(itemsCollection, dataWithMeta);
+  await logAuditEvent('create', docRef.id, { createdData: dataWithMeta });
   return docRef.id;
 };
 
 export const updateSinopticoItem = async (id, itemData) => {
-  const itemDoc = doc(db, SINOPTICO_ITEMS_COLLECTION, id);
-  await updateDoc(itemDoc, itemData);
+  const itemDocRef = doc(db, SINOPTICO_ITEMS_COLLECTION, id);
+  const user = auth.currentUser;
+
+  const docSnap = await getDoc(itemDocRef);
+  if (!docSnap.exists()) {
+    throw new Error("Document not found");
+  }
+  const beforeData = docSnap.data();
+
+  const dataWithMeta = {
+    ...itemData,
+    lastModifiedBy: user?.email,
+    lastModifiedAt: serverTimestamp(),
+  };
+
+  await updateDoc(itemDocRef, dataWithMeta);
+
+  const changes = Object.keys(dataWithMeta).reduce((acc, key) => {
+    if (beforeData[key] !== dataWithMeta[key]) {
+      acc[key] = {
+        from: beforeData[key] ?? null,
+        to: dataWithMeta[key],
+      };
+    }
+    return acc;
+  }, {});
+
+  if (Object.keys(changes).length > 0) {
+    await logAuditEvent('update', id, { changes });
+  }
 };
 
 export const deleteSinopticoItem = async (id) => {
+  await logAuditEvent('delete', id);
   const itemDoc = doc(db, SINOPTICO_ITEMS_COLLECTION, id);
   await deleteDoc(itemDoc);
+};
+
+export const getAuditLogsForItem = async (itemId) => {
+  const logsCollection = collection(db, AUDIT_LOGS_COLLECTION);
+  const q = query(
+    logsCollection,
+    where('itemId', '==', itemId),
+    orderBy('timestamp', 'desc')
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 };
 
 export const getSinopticoItemsCount = async () => {


### PR DESCRIPTION
This commit introduces an audit log feature for each item in the product's synoptic view.

- A new 'History' icon is added to each item row in edit mode.
- Clicking the icon opens a modal displaying the item's creation and last modification details, including the user and date.
- The `sinopticoItemsService` is updated to record creation and update events in a new `audit_logs` collection in Firestore.
- A new `AuditLogModal` component is created to display the audit trail for a specific item.