### PR TITLE
feat: Improve sinoptico visuals and add fields to caratula

### DIFF
--- a/src/components/Caratula.jsx
+++ b/src/components/Caratula.jsx
@@ -4,7 +4,18 @@ import { getCaratulaData, saveCaratulaData } from '../services/caratulaService';
 import { PencilIcon, CheckIcon } from '@heroicons/react/24/solid';
 
 function Caratula() {
-  const [caratulaData, setCaratulaData] = useState({ elaboradoPor: '', revisadoPor: '', proyectoId: '' });
+  const [caratulaData, setCaratulaData] = useState({
+    elaboradoPor: '',
+    revisadoPor: '',
+    proyectoId: '',
+    fechaEmision: '',
+    revision: '',
+    nombreParte: '',
+    fechaRevision: '',
+    numeroParte: '',
+    version: '',
+    autor: '',
+  });
   const [projects, setProjects] = useState([]);
   const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -83,9 +94,10 @@ function Caratula() {
         )}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        {/* Row 1 */}
         <div>
-          <label className="block text-sm font-medium text-gray-500 mb-1">Proyecto</label>
+          <label className="block text-sm font-medium text-gray-500 mb-1">PROYECTO</label>
           {isEditing ? (
             <select
               name="proyectoId"
@@ -103,29 +115,79 @@ function Caratula() {
           )}
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-500 mb-1">Elaborado por</label>
+          <label className="block text-sm font-medium text-gray-500 mb-1">Fecha de emisión</label>
           {isEditing ? (
-            <input
-              type="text"
-              name="elaboradoPor"
-              value={caratulaData.elaboradoPor}
-              onChange={handleChange}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-            />
+            <input type="text" name="fechaEmision" value={caratulaData.fechaEmision} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+          ) : (
+            <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.fechaEmision || 'N/A'}</p>
+          )}
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-500 mb-1">Revisión</label>
+          {isEditing ? (
+            <input type="text" name="revision" value={caratulaData.revision} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+          ) : (
+            <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.revision || 'N/A'}</p>
+          )}
+        </div>
+        <div></div> {/* Empty cell for spacing */}
+
+        {/* Row 2 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-500 mb-1">NOMBRE DE PARTE</label>
+          {isEditing ? (
+            <input type="text" name="nombreParte" value={caratulaData.nombreParte} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+          ) : (
+            <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.nombreParte || 'N/A'}</p>
+          )}
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-500 mb-1">Realizó</label>
+          {isEditing ? (
+            <input type="text" name="elaboradoPor" value={caratulaData.elaboradoPor} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
           ) : (
             <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.elaboradoPor || 'N/A'}</p>
           )}
         </div>
         <div>
+          <label className="block text-sm font-medium text-gray-500 mb-1">Fecha revisión</label>
+          {isEditing ? (
+            <input type="text" name="fechaRevision" value={caratulaData.fechaRevision} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+          ) : (
+            <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.fechaRevision || 'N/A'}</p>
+          )}
+        </div>
+        <div></div> {/* Empty cell for spacing */}
+
+        {/* Row 3 */}
+        <div>
+          <label className="block text-sm font-medium text-gray-500 mb-1">NÚMERO DE PARTE</label>
+          {isEditing ? (
+            <input type="text" name="numeroParte" value={caratulaData.numeroParte} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+          ) : (
+            <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.numeroParte || 'N/A'}</p>
+          )}
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-500 mb-1">Versión</label>
+          {isEditing ? (
+            <input type="text" name="version" value={caratulaData.version} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+          ) : (
+            <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.version || 'N/A'}</p>
+          )}
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-500 mb-1">Autor</label>
+          {isEditing ? (
+            <input type="text" name="autor" value={caratulaData.autor} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+          ) : (
+            <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.autor || 'N/A'}</p>
+          )}
+        </div>
+        <div>
           <label className="block text-sm font-medium text-gray-500 mb-1">Revisado por</label>
           {isEditing ? (
-            <input
-              type="text"
-              name="revisadoPor"
-              value={caratulaData.revisadoPor}
-              onChange={handleChange}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-            />
+            <input type="text" name="revisadoPor" value={caratulaData.revisadoPor} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
           ) : (
             <p className="text-lg font-semibold text-gray-800 p-2 bg-gray-50 rounded-md">{caratulaData.revisadoPor || 'N/A'}</p>
           )}

--- a/src/pages/SinopticoNode.jsx
+++ b/src/pages/SinopticoNode.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, memo } from 'react';
 import { ChevronRightIcon, ChevronDownIcon, PencilIcon, PlusCircleIcon, ClockIcon, ArrowPathIcon } from '@heroicons/react/24/solid';
 import { useQuickUpdate } from '../hooks/useQuickUpdate';
 
-const SinopticoNode = ({ node, level, editMode, onEdit, onQuickUpdate, onOpenAuditLog }) => {
+const SinopticoNode = ({ node, level, isLastChild, editMode, onEdit, onQuickUpdate, onOpenAuditLog }) => {
   const [isOpen, setIsOpen] = useState(true);
   const [editingField, setEditingField] = useState(null); // 'nombre', 'codigo', or null
   const [editValue, setEditValue] = useState('');
@@ -84,7 +84,7 @@ const SinopticoNode = ({ node, level, editMode, onEdit, onQuickUpdate, onOpenAud
   };
 
 
-  const indentation = { paddingLeft: `${level * 2}rem` };
+  const indentation = { paddingLeft: `${level * 1.5 + 1.5}rem` };
 
   const typeColor = {
     producto: 'bg-blue-100 text-blue-800',
@@ -92,12 +92,23 @@ const SinopticoNode = ({ node, level, editMode, onEdit, onQuickUpdate, onOpenAud
     insumo: 'bg-yellow-100 text-yellow-800',
   };
 
+  const TreeLine = () => {
+    if (level === 0) return null;
+    return (
+      <div className="absolute top-0 h-full" style={{ left: `${(level - 1) * 1.5 + 0.75}rem`, width: '1.5rem' }}>
+        <div className={`h-full w-0.5 bg-gray-300 ${isLastChild ? 'h-1/2' : 'h-full'}`}></div>
+        <div className="absolute top-1/2 w-full h-0.5 bg-gray-300"></div>
+      </div>
+    );
+  };
+
   return (
-    <div>
-      <div className={`grid grid-cols-9 gap-4 px-4 py-3 items-center border-b border-gray-100 ${editMode ? 'hover:bg-gray-50' : ''}`}>
-        <div className="col-span-3 flex items-center" style={indentation}>
+    <div className="relative">
+      <TreeLine />
+      <div className={`grid grid-cols-9 gap-4 px-4 py-3 items-center ${editMode ? 'hover:bg-gray-50' : ''}`}>
+        <div className="col-span-3 flex items-center relative" style={indentation}>
           {hasChildren ? (
-            <button onClick={toggleOpen} className="mr-2 text-gray-500">
+            <button onClick={toggleOpen} className="mr-2 text-gray-500 z-10">
               {isOpen ? <ChevronDownIcon className="h-4 w-4" /> : <ChevronRightIcon className="h-4 w-4" />}
             </button>
           ) : (
@@ -136,12 +147,13 @@ const SinopticoNode = ({ node, level, editMode, onEdit, onQuickUpdate, onOpenAud
         )}
       </div>
       {isOpen && hasChildren && (
-        <div className="bg-white">
-          {node.children.map(childNode => (
+        <div>
+          {node.children.map((childNode, index) => (
             <SinopticoNode
               key={childNode.id}
               node={childNode}
               level={level + 1}
+              isLastChild={index === node.children.length - 1}
               editMode={editMode}
               onEdit={onEdit}
               onQuickUpdate={onQuickUpdate}

--- a/src/pages/SinopticoPage.jsx
+++ b/src/pages/SinopticoPage.jsx
@@ -175,8 +175,17 @@ const SinopticoPage = () => {
               <div className="border rounded-lg overflow-hidden">
                 {renderHeader()}
                 <div className="divide-y divide-gray-200">
-                  {hierarchy.map(node => (
-                    <SinopticoNode key={node.id} node={node} level={0} editMode={editMode} onEdit={handleOpenModal} onOpenAuditLog={handleOpenAuditLogModal} onQuickUpdate={handleQuickUpdate} />
+                  {hierarchy.map((node, index) => (
+                    <SinopticoNode
+                      key={node.id}
+                      node={node}
+                      level={0}
+                      isLastChild={index === hierarchy.length - 1}
+                      editMode={editMode}
+                      onEdit={handleOpenModal}
+                      onOpenAuditLog={handleOpenAuditLogModal}
+                      onQuickUpdate={handleQuickUpdate}
+                    />
                   ))}
                 </div>
               </div>

--- a/src/services/caratulaService.js
+++ b/src/services/caratulaService.js
@@ -15,6 +15,13 @@ export const getCaratulaData = async () => {
       elaboradoPor: '',
       revisadoPor: '',
       proyectoId: '',
+      fechaEmision: '',
+      revision: '',
+      nombreParte: '',
+      fechaRevision: '',
+      numeroParte: '',
+      version: '',
+      autor: '',
     };
   }
 };


### PR DESCRIPTION
This commit introduces two main improvements to the sinoptico module:

1.  **Caratula Enhancement**: The `Caratula` component has been updated to include several new fields as requested by the user. The layout has been adjusted to a 4-column grid to accommodate the new fields, and the labels have been updated to be in Spanish.

2.  **Hierarchy Visualization**: The `SinopticoNode` component now displays lines to visually represent the hierarchical tree structure. This makes it easier to understand the relationships between the different nodes in the sinoptico.