### PR TITLE
feat: Create a Firebase CRUD service factory

### DIFF
--- a/src/services/firebaseServiceFactory.js
+++ b/src/services/firebaseServiceFactory.js
@@ -1,0 +1,60 @@
+import {
+  db,
+  collection,
+  getDocs,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc
+} from './firebase';
+
+export const createCrudService = (collectionName) => {
+  const dataCollection = collection(db, collectionName);
+
+  const get = async () => {
+    try {
+      const snapshot = await getDocs(dataCollection);
+      return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    } catch (error) {
+      console.error(`Error al obtener datos de ${collectionName}:`, error);
+      throw new Error(`No se pudieron obtener los datos de ${collectionName}.`);
+    }
+  };
+
+  const add = async (data) => {
+    try {
+      const docRef = await addDoc(dataCollection, data);
+      return docRef.id;
+    } catch (error) {
+      console.error(`Error al añadir dato en ${collectionName}:`, error);
+      throw new Error(`No se pudo añadir el dato en ${collectionName}.`);
+    }
+  };
+
+  const update = async (id, data) => {
+    try {
+      const dataDoc = doc(db, collectionName, id);
+      await updateDoc(dataDoc, data);
+    } catch (error) {
+      console.error(`Error al actualizar dato en ${collectionName}:`, error);
+      throw new Error(`No se pudo actualizar el dato en ${collectionName}.`);
+    }
+  };
+
+  const remove = async (id) => {
+    try {
+      const dataDoc = doc(db, collectionName, id);
+      await deleteDoc(dataDoc);
+    } catch (error) {
+      console.error(`Error al eliminar dato de ${collectionName}:`, error);
+      throw new Error(`No se pudo eliminar el dato de ${collectionName}.`);
+    }
+  };
+
+  return {
+    get,
+    add,
+    update,
+    delete: remove,
+  };
+};

--- a/src/services/modules/clientesService.js
+++ b/src/services/modules/clientesService.js
@@ -1,58 +1,14 @@
-import {
-  db,
-  collection,
-  getDocs,
-  addDoc,
-  updateDoc,
-  deleteDoc,
-  doc
-} from '../firebase';
+import { createCrudService } from '../firebaseServiceFactory';
+import { db, collection, getDocs } from '../firebase';
 
 const CLIENTES_COLLECTION = 'clientes';
 
-export const getClientes = async () => {
-  try {
-    const clientesCollection = collection(db, CLIENTES_COLLECTION);
-    const snapshot = await getDocs(clientesCollection);
-    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-  } catch (error) {
-    // Log the error for debugging purposes
-    console.error("Error al obtener clientes:", error);
-    // Re-throw the error to be handled by the calling component
-    throw new Error("No se pudieron obtener los clientes. Por favor, intente de nuevo más tarde.");
-  }
-};
+const clienteCrudService = createCrudService(CLIENTES_COLLECTION);
 
-export const addCliente = async (clienteData) => {
-  try {
-    const clientesCollection = collection(db, CLIENTES_COLLECTION);
-    const docRef = await addDoc(clientesCollection, clienteData);
-    return docRef.id;
-  } catch (error) {
-    console.error("Error al añadir cliente:", error);
-    throw new Error("No se pudo añadir el cliente. Por favor, intente de nuevo más tarde.");
-  }
-};
-
-export const updateCliente = async (id, clienteData) => {
-  try {
-    const clienteDoc = doc(db, CLIENTES_COLLECTION, id);
-    await updateDoc(clienteDoc, clienteData);
-  } catch (error) {
-    console.error("Error al actualizar cliente:", error);
-    throw new Error("No se pudo actualizar el cliente. Por favor, intente de nuevo más tarde.");
-  }
-};
-
-export const deleteCliente = async (id) => {
-  try {
-    const clienteDoc = doc(db, CLIENTES_COLLECTION, id);
-    await deleteDoc(clienteDoc);
-  } catch (error) {
-    console.error("Error al eliminar cliente:", error);
-    throw new Error("No se pudo eliminar el cliente. Por favor, intente de nuevo más tarde.");
-  }
-};
+export const getClientes = clienteCrudService.get;
+export const addCliente = clienteCrudService.add;
+export const updateCliente = clienteCrudService.update;
+export const deleteCliente = clienteCrudService.delete;
 
 export const getClientesCount = async () => {
   try {


### PR DESCRIPTION
This commit introduces a generic `createCrudService` factory for Firestore operations. The factory creates a service object with `get`, `add`, `update`, and `delete` methods for a given collection.

The `clientesService` has been refactored to use this new factory, reducing code duplication and improving maintainability. The custom `getClientesCount` function remains in the service as it is not a generic CRUD operation.