### PR TITLE
Refactor(firestore): Add validation to 'clientes' collection rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -24,7 +24,10 @@ service cloud.firestore {
     // Solo el creador del documento o un administrador puede leer o escribir.
     // Asume que cada documento tiene un campo 'createdBy' con el UID del creador.
     match /clientes/{clienteId} {
-      allow read, write: if request.resource.data.createdBy == request.auth.uid || isAdmin();
+      allow read: if resource.data.createdBy == request.auth.uid || isAdmin();
+      allow write: if (request.resource.data.createdBy == request.auth.uid || isAdmin())
+                      && request.resource.data.nombre is string
+                      && request.resource.data.nombre.size() > 0;
     }
 
     match /insumos/{insumoId} {


### PR DESCRIPTION
This commit modifies the security rules in `firestore.rules` for the 'clientes' collection.

The `allow write` rule has been updated to include a validation check. This ensures that any data written to the 'clientes' collection contains a 'nombre' field that is a non-empty string.

Additionally, the `allow read` and `allow write` rules have been separated for clarity and correctness. The `read` rule now correctly uses `resource.data` instead of `request.resource.data`.