### PR TITLE
feat: Add subtle animations and transitions to the UI

### DIFF
--- a/src/components/CrudPage.jsx
+++ b/src/components/CrudPage.jsx
@@ -120,7 +120,15 @@ function CrudPage({
   };
 
   return (
-    <div className="h-full flex flex-col">
+    <Transition
+      appear
+      show={true}
+      as="div"
+      className="h-full flex flex-col"
+      enter="transition-opacity duration-500"
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+    >
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold text-gray-800">{entityNamePlural}</h1>
         <button
@@ -170,7 +178,7 @@ function CrudPage({
         item={selectedItem}
         title={infoTitle}
       />
-    </div>
+    </Transition>
   );
 }
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -72,11 +72,11 @@ function Layout() {
               <Link
                 key={item.text}
                 to={item.path}
-                className={`flex items-center px-4 py-3 my-1 text-secondary rounded-lg transition-all duration-200 ease-in-out transform hover:bg-background hover:text-primary hover:scale-105 ${
+                className={`flex items-center px-4 py-3 my-1 text-secondary rounded-lg transition-all duration-200 ease-in-out transform hover:bg-background hover:text-primary hover:scale-105 group ${
                   location.pathname === item.path ? 'bg-primary text-white shadow-inner' : 'hover:bg-background'
                 }`}
               >
-                <item.icon className="h-6 w-6 mr-3" />
+                <item.icon className="h-6 w-6 mr-3 transition-transform duration-200 ease-in-out group-hover:rotate-6" />
                 <span className="font-medium">{item.text}</span>
               </Link>
             ))}


### PR DESCRIPTION
This commit introduces two new UI enhancements:

1.  In `src/components/Layout.jsx`, the sidebar icons now have a `hover:rotate-6` effect, providing a subtle visual feedback to the user.
2.  In `src/components/CrudPage.jsx`, the main content area is now wrapped in a Headless UI `Transition` component, which creates a smooth fade-in effect on page load.