### PR TITLE
Fix: Resolve Tailwind CSS build error

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,15 @@
-@import "tailwindcss";
+@config "../tailwind.config.js";
+@reference "tailwindcss";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 /* AG Grid Quartz Theme Customizations */
 .ag-theme-quartz {
-  --ag-header-background-color: theme(colors.background);
+  --ag-header-background-color: var(--color-background);
   --ag-border-color: transparent;
-  --ag-row-border-color: theme(colors.gray.200);
+  --ag-row-border-color: var(--color-gray-200);
 }
 
 /* Add a subtle transition for a smoother hover effect */
@@ -14,7 +19,7 @@
 
 /* Apply a light background color on row hover for better interactivity */
 .ag-theme-quartz .ag-row:hover .ag-cell {
-  background-color: theme(colors.gray.100);
+  background-color: var(--color-gray-100);
 }
 
 body {


### PR DESCRIPTION
The build was failing with an error related to the `theme()` function in `src/index.css`. This was caused by a combination of issues related to Tailwind CSS v4 setup.

The following changes were made to resolve the issue:
- Replaced the deprecated `theme()` function with CSS variables (e.g., `var(--color-background)`).
- Replaced the non-standard `@import "tailwindcss";` with the correct `@tailwind` directives.
- Added `@config "../tailwind.config.js";` and `@reference "tailwindcss";` to `src/index.css` to ensure that both custom theme values and default utilities are available to `@apply`.