### PR TITLE
Fix a critical bug in `src/pages/ProductosPage.jsx`.

### DIFF
--- a/src/pages/ProductosPage.jsx
+++ b/src/pages/ProductosPage.jsx
@@ -32,7 +32,7 @@ function ProductosPage() {
   const [selectedProducto, setSelectedProducto] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deletingProductoId, setDeletingProductoId] = useState(null);
-  const { user } = useAuth();
+  const { currentUser } = useAuth();
 
   const fetchTopLevelProducts = useCallback(async () => {
     setLoading(true);
@@ -65,7 +65,7 @@ function ProductosPage() {
       if (editingProducto) {
         await updateProducto(editingProducto.id, productoData);
       } else {
-        await createNewProduct(productoData, user.uid);
+        await createNewProduct(productoData, currentUser.uid);
       }
       handleCloseModal();
       fetchTopLevelProducts();


### PR DESCRIPTION
In the `handleSaveProducto` function, the call to `createNewProduct` was using `user.uid`, but the `user` variable was undefined. This was because the `useAuth` hook returns a `currentUser` object, not a `user` object.

This commit fixes the bug by:
1.  Correctly destructuring `currentUser` from the `useAuth` hook.
2.  Using `currentUser.uid` when calling `createNewProduct`.