### PR TITLE
feat: Add 'Código Cliente' field to products

### DIFF
--- a/src/components/ProductoModal.jsx
+++ b/src/components/ProductoModal.jsx
@@ -9,6 +9,7 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
     descripcion: '',
     unidad_medida: '',
     proyecto: '',
+    codigo_cliente: '',
   });
   const [proyectos, setProyectos] = useState([]);
 
@@ -31,6 +32,7 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
         descripcion: producto.descripcion || '',
         unidad_medida: producto.unidad_medida || '',
         proyecto: producto.proyecto || '',
+        codigo_cliente: producto.codigo_cliente || '',
       });
     } else {
       setFormData({
@@ -38,6 +40,7 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
         descripcion: '',
         unidad_medida: '',
         proyecto: '',
+        codigo_cliente: '',
       });
     }
   }, [producto, open]);
@@ -100,6 +103,19 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
                           name="codigo"
                           id="codigo"
                           value={formData.codigo}
+                          onChange={handleChange}
+                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                        />
+                      </div>
+                      <div>
+                        <label htmlFor="codigo_cliente" className="block text-sm font-medium text-gray-700">
+                          Código Cliente
+                        </label>
+                        <input
+                          type="text"
+                          name="codigo_cliente"
+                          id="codigo_cliente"
+                          value={formData.codigo_cliente}
                           onChange={handleChange}
                           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                         />

--- a/src/pages/ProductosPage.jsx
+++ b/src/pages/ProductosPage.jsx
@@ -97,6 +97,7 @@ function ProductosPage() {
 
   const columnDefs = useMemo(() => [
     { headerName: "Código", field: "codigo", flex: 1, sortable: true, filter: true },
+    { headerName: "Código Cliente", field: "codigo_cliente", flex: 1, sortable: true, filter: true },
     { headerName: "Descripción", field: "descripcion", flex: 2, sortable: true, filter: true },
     { headerName: "Unidad de Medida", field: "unidad_medida", flex: 1, sortable: true, filter: true },
     { headerName: "Proyecto", field: "proyecto", flex: 1, sortable: true, filter: true },


### PR DESCRIPTION
This commit introduces a new 'Código Cliente' (Client Code) field to the product entity.

Changes include:
- In `src/components/ProductoModal.jsx`:
  - Added a new text input for 'Código Cliente' to the product creation/editing modal.
  - Updated the component's state to manage the `codigo_cliente` value.
- In `src/pages/ProductosPage.jsx`:
  - Added a 'Código Cliente' column to the main products data grid to make the new field visible.