### PR TITLE
Simplifies the product and sub-product modals.

### DIFF
--- a/src/components/ProductoModal.jsx
+++ b/src/components/ProductoModal.jsx
@@ -1,13 +1,11 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { getProyectos } from '../services/modules/proyectosService';
-import { UNITS } from '../constants/units';
 
 const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
   const [formData, setFormData] = useState({
     codigo: '',
     descripcion: '',
-    unidad_medida: '',
     proyecto: '',
     codigo_cliente: '',
   });
@@ -30,7 +28,6 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
       setFormData({
         codigo: producto.codigo || '',
         descripcion: producto.descripcion || '',
-        unidad_medida: producto.unidad_medida || '',
         proyecto: producto.proyecto || '',
         codigo_cliente: producto.codigo_cliente || '',
       });
@@ -38,7 +35,6 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
       setFormData({
         codigo: '',
         descripcion: '',
-        unidad_medida: '',
         proyecto: '',
         codigo_cliente: '',
       });
@@ -51,11 +47,11 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
   };
 
   const handleSave = () => {
-    if (!formData.codigo || !formData.descripcion || !formData.unidad_medida || !formData.proyecto) {
+    if (!formData.codigo || !formData.descripcion || !formData.proyecto) {
       alert('Todos los campos son obligatorios.');
       return;
     }
-    onSave(formData);
+    onSave({ ...formData, unidad_medida: 'un' });
   };
 
   return (
@@ -132,23 +128,6 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
                           onChange={handleChange}
                           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                         />
-                      </div>
-                      <div>
-                        <label htmlFor="unidad_medida" className="block text-sm font-medium text-gray-700">
-                          Unidad de Medida
-                        </label>
-                        <select
-                          id="unidad_medida"
-                          name="unidad_medida"
-                          value={formData.unidad_medida}
-                          onChange={handleChange}
-                          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                        >
-                          <option value="">Seleccione una unidad</option>
-                          {UNITS.map(unit => (
-                            <option key={unit.id} value={unit.id}>{unit.nombre} ({unit.abreviatura})</option>
-                          ))}
-                        </select>
                       </div>
                       <div>
                         <label htmlFor="proyecto" className="block text-sm font-medium text-gray-700">

--- a/src/components/SubproductoModal.jsx
+++ b/src/components/SubproductoModal.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
-import { UNITS } from '../constants/units';
 
 const SubproductoModal = forwardRef(({ open, onClose, onSave, subproducto }, ref) => {
   const [formData, setFormData] = useState({
@@ -9,7 +8,6 @@ const SubproductoModal = forwardRef(({ open, onClose, onSave, subproducto }, ref
     codigo: '',
     peso: '',
     medidas: '',
-    unidad_medida: '',
     id_padre: null, // This can be set from the component that opens the modal
   });
 
@@ -21,7 +19,6 @@ const SubproductoModal = forwardRef(({ open, onClose, onSave, subproducto }, ref
         codigo: subproducto.codigo || '',
         peso: subproducto.peso || '',
         medidas: subproducto.medidas || '',
-        unidad_medida: subproducto.unidad_medida || '',
         id_padre: subproducto.id_padre || null,
       });
     } else {
@@ -31,7 +28,6 @@ const SubproductoModal = forwardRef(({ open, onClose, onSave, subproducto }, ref
         codigo: '',
         peso: '',
         medidas: '',
-        unidad_medida: '',
         id_padre: null,
       });
     }
@@ -48,7 +44,7 @@ const SubproductoModal = forwardRef(({ open, onClose, onSave, subproducto }, ref
       alert('Nombre y Código son campos obligatorios.');
       return;
     }
-    onSave(formData);
+    onSave({ ...formData, unidad_medida: 'un' });
   };
 
   return (
@@ -102,21 +98,6 @@ const SubproductoModal = forwardRef(({ open, onClose, onSave, subproducto }, ref
                     <div>
                       <label htmlFor="medidas" className="block text-sm font-medium text-gray-700">Medidas</label>
                       <input type="text" name="medidas" id="medidas" value={formData.medidas} onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
-                    </div>
-                    <div>
-                      <label htmlFor="unidad_medida" className="block text-sm font-medium text-gray-700">Unidad de Medida</label>
-                      <select
-                        id="unidad_medida"
-                        name="unidad_medida"
-                        value={formData.unidad_medida}
-                        onChange={handleChange}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                      >
-                        <option value="">Seleccione una unidad</option>
-                        {UNITS.map(unit => (
-                          <option key={unit.id} value={unit.id}>{unit.nombre} ({unit.abreviatura})</option>
-                        ))}
-                      </select>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
- Removes the select field for "Unidad de Medida" from `src/components/ProductoModal.jsx` and `src/components/SubproductoModal.jsx`.
- Modifies the `handleSave` function in both components to automatically assign the value 'un' to the `unidad_medida` field in `formData` before saving.