### PR TITLE
style: Centrar los íconos de acción en ActionsCellRenderer

### DIFF
--- a/src/components/ActionsCellRenderer.jsx
+++ b/src/components/ActionsCellRenderer.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { InformationCircleIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
 
 const ActionsCellRenderer = ({ data, onInfo, onEdit, onDelete }) => (
-  <div className="flex items-center justify-end space-x-2">
+  <div className="flex items-center justify-center space-x-2">
     <button data-testid="info-button" onClick={() => onInfo(data)} className="text-blue-600 hover:text-blue-900 transition-colors duration-200">
       <InformationCircleIcon className="h-5 w-5" />
     </button>


### PR DESCRIPTION
Se cambió la clase `justify-end` por `justify-center` en el `div` principal del componente `ActionsCellRenderer` para centrar los íconos de acción (editar, eliminar, info) dentro de su columna en todas las tablas de la aplicación.