### PR TITLE
feat: Disable drag and drop for the root product

### DIFF
--- a/src/pages/SinopticoPage.jsx
+++ b/src/pages/SinopticoPage.jsx
@@ -398,7 +398,7 @@ const SinopticoPage = () => {
                           onOpenAuditLog={handleOpenAuditLogModal}
                           onQuickUpdate={handleQuickUpdate}
                           isOver={overId === node.id}
-                          disabled={!editMode}
+                          disabled={node.level === 0 || !editMode}
                           isCollapsed={collapsedNodes.has(node.id)}
                           onToggleNode={handleToggleNode}
                         />


### PR DESCRIPTION
This commit disables the drag-and-drop functionality for the root product in the synoptic view. This prevents users from accidentally moving the root element of the hierarchy.

The changes include:
- Modifying `SinopticoPage.jsx` to update the `disabled` prop for the `DraggableSinopticoNode` component. The logic is now `disabled={node.level === 0 || !editMode}`.