### PR TITLE
Refactor: Use generic CrudPage for Proveedores and Proyectos

### DIFF
--- a/src/pages/ProveedoresPage.jsx
+++ b/src/pages/ProveedoresPage.jsx
@@ -1,98 +1,17 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React from 'react';
 import { getProveedores, addProveedor, updateProveedor, deleteProveedor } from '../services/modules/proveedoresService';
 import ProveedorModal from '../components/ProveedorModal';
-import InfoModal from '../components/InfoModal';
-import ConfirmDialog from '../components/ConfirmDialog';
-import DataGrid from '../components/DataGrid';
-import { PlusIcon, PencilIcon, TrashIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
-import { Transition } from '@headlessui/react';
+import CrudPage from '../components/CrudPage';
 
-const ActionsCellRenderer = ({ data, onInfo, onEdit, onDelete }) => (
-  <div className="flex items-center justify-end space-x-2">
-    <button data-testid="info-button" onClick={() => onInfo(data)} className="text-blue-600 hover:text-blue-900 transition-colors duration-200">
-      <InformationCircleIcon className="h-5 w-5" />
-    </button>
-    <button data-testid="edit-button" onClick={() => onEdit(data)} className="text-indigo-600 hover:text-indigo-900 transition-colors duration-200">
-      <PencilIcon className="h-5 w-5" />
-    </button>
-    <button data-testid="delete-button" onClick={() => onDelete(data.id)} className="text-red-600 hover:text-red-900 transition-colors duration-200">
-      <TrashIcon className="h-5 w-5" />
-    </button>
-  </div>
-);
-
-function ProveedoresPage() {
-  const [proveedores, setProveedores] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editingProveedor, setEditingProveedor] = useState(null);
-  const [infoModalOpen, setInfoModalOpen] = useState(false);
-  const [selectedProveedor, setSelectedProveedor] = useState(null);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [deletingProveedorId, setDeletingProveedorId] = useState(null);
-
-  const fetchProveedores = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await getProveedores();
-      setProveedores(data);
-    } catch (error) {
-      console.error("Error fetching suppliers:", error);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchProveedores();
-  }, [fetchProveedores]);
-
-  const handleOpenModal = (proveedor = null) => {
-    setEditingProveedor(proveedor);
-    setModalOpen(true);
+const ProveedoresPage = () => {
+  const services = {
+    get: getProveedores,
+    add: addProveedor,
+    update: updateProveedor,
+    delete: deleteProveedor,
   };
 
-  const handleCloseModal = () => {
-    setModalOpen(false);
-    setEditingProveedor(null);
-  };
-
-  const handleSaveProveedor = async (proveedorData) => {
-    try {
-      if (editingProveedor) {
-        await updateProveedor(editingProveedor.id, proveedorData);
-      } else {
-        await addProveedor(proveedorData);
-      }
-      handleCloseModal();
-      fetchProveedores();
-    } catch (error) {
-      console.error("Error saving supplier:", error);
-    }
-  };
-
-  const handleDeleteClick = (id) => {
-    setDeletingProveedorId(id);
-    setConfirmOpen(true);
-  };
-
-  const handleDeleteConfirm = async () => {
-    try {
-      await deleteProveedor(deletingProveedorId);
-      setConfirmOpen(false);
-      setDeletingProveedorId(null);
-      fetchProveedores();
-    } catch (error) {
-      console.error("Error deleting supplier:", error);
-    }
-  };
-
-  const handleInfo = (proveedor) => {
-    setSelectedProveedor(proveedor);
-    setInfoModalOpen(true);
-  };
-
-  const columnDefs = useMemo(() => [
+  const columnDefsFactory = ({ onEdit, onDelete, onInfo }) => [
     { headerName: "Razón Social", field: "razonSocial", flex: 2, sortable: true, filter: true },
     { headerName: "Dirección", field: "direccion", flex: 2, sortable: true, filter: true },
     { headerName: "Teléfono", field: "telefono", flex: 1, sortable: true, filter: true },
@@ -102,9 +21,9 @@ function ProveedoresPage() {
       headerName: "Acciones",
       cellRenderer: 'actionsCellRenderer',
       cellRendererParams: {
-        onInfo: handleInfo,
-        onEdit: handleOpenModal,
-        onDelete: handleDeleteClick,
+        onInfo,
+        onEdit,
+        onDelete,
       },
       flex: 0.5,
       sortable: false,
@@ -112,66 +31,19 @@ function ProveedoresPage() {
       resizable: false,
       pinned: 'right',
     }
-  ], []);
+  ];
 
   return (
-    <div className="h-full flex flex-col">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold text-gray-800">Proveedores</h1>
-        <button
-          onClick={() => handleOpenModal()}
-          className="inline-flex items-center px-4 py-2 bg-indigo-600 text-white font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 shadow-sm transition-all duration-200 ease-in-out transform hover:scale-105"
-        >
-          <PlusIcon className="h-5 w-5 mr-2" />
-          Añadir Proveedor
-        </button>
-      </div>
-
-      <div className="flex-grow bg-white shadow-lg rounded-lg overflow-hidden">
-        <DataGrid
-          rowData={proveedores}
-          columnDefs={columnDefs}
-          loading={loading}
-          components={{
-            actionsCellRenderer: ActionsCellRenderer,
-          }}
-        />
-      </div>
-
-      <Transition
-        show={modalOpen}
-        as={React.Fragment}
-        enter="transition-opacity duration-300"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-300"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <ProveedorModal
-          open={modalOpen}
-          onClose={handleCloseModal}
-          onSave={handleSaveProveedor}
-          proveedor={editingProveedor}
-        />
-      </Transition>
-
-      <ConfirmDialog
-        open={confirmOpen}
-        onClose={() => setConfirmOpen(false)}
-        onConfirm={handleDeleteConfirm}
-        title="Confirmar Eliminación"
-        message="¿Estás seguro de que quieres eliminar este proveedor? Esta acción no se puede deshacer."
-      />
-
-      <InfoModal
-        open={infoModalOpen}
-        onClose={() => setInfoModalOpen(false)}
-        item={selectedProveedor}
-        title="Información del Proveedor"
-      />
-    </div>
+    <CrudPage
+      services={services}
+      columnDefsFactory={columnDefsFactory}
+      ModalComponent={ProveedorModal}
+      entityName="Proveedor"
+      entityNamePlural="Proveedores"
+      infoTitle="Información del Proveedor"
+      modalEntityPropName="proveedor"
+    />
   );
-}
+};
 
 export default ProveedoresPage;

--- a/src/pages/ProyectosPage.jsx
+++ b/src/pages/ProyectosPage.jsx
@@ -1,96 +1,26 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React from 'react';
 import { getProyectos, addProyecto, updateProyecto, deleteProyecto } from '../services/modules/proyectosService';
 import ProyectoModal from '../components/ProyectoModal';
-import InfoModal from '../components/InfoModal';
-import ConfirmDialog from '../components/ConfirmDialog';
-import DataGrid from '../components/DataGrid';
-import { PlusIcon } from '@heroicons/react/24/outline';
-import { Transition } from '@headlessui/react';
-import ActionsCellRenderer from '../components/ActionsCellRenderer';
-import GridSkeletonLoader from '../components/GridSkeletonLoader';
-import EmptyState from '../components/EmptyState';
+import CrudPage from '../components/CrudPage';
 
-function ProyectosPage() {
-  const [proyectos, setProyectos] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editingProyecto, setEditingProyecto] = useState(null);
-  const [infoModalOpen, setInfoModalOpen] = useState(false);
-  const [selectedProyecto, setSelectedProyecto] = useState(null);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [deletingProyectoId, setDeletingProyectoId] = useState(null);
-
-  const fetchProyectos = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await getProyectos();
-      setProyectos(data);
-    } catch (error) {
-      console.error("Error fetching projects:", error);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchProyectos();
-  }, [fetchProyectos]);
-
-  const handleOpenModal = (proyecto = null) => {
-    setEditingProyecto(proyecto);
-    setModalOpen(true);
+const ProyectosPage = () => {
+  const services = {
+    get: getProyectos,
+    add: addProyecto,
+    update: updateProyecto,
+    delete: deleteProyecto,
   };
 
-  const handleCloseModal = () => {
-    setModalOpen(false);
-    setEditingProyecto(null);
-  };
-
-  const handleSaveProyecto = async (proyectoData) => {
-    try {
-      if (editingProyecto) {
-        await updateProyecto(editingProyecto.id, proyectoData);
-      } else {
-        await addProyecto(proyectoData);
-      }
-      handleCloseModal();
-      fetchProyectos();
-    } catch (error) {
-      console.error("Error saving project:", error);
-    }
-  };
-
-  const handleDeleteClick = (id) => {
-    setDeletingProyectoId(id);
-    setConfirmOpen(true);
-  };
-
-  const handleDeleteConfirm = async () => {
-    try {
-      await deleteProyecto(deletingProyectoId);
-      setConfirmOpen(false);
-      setDeletingProyectoId(null);
-      fetchProyectos();
-    } catch (error) {
-      console.error("Error deleting project:", error);
-    }
-  };
-
-  const handleInfo = (proyecto) => {
-    setSelectedProyecto(proyecto);
-    setInfoModalOpen(true);
-  };
-
-  const columnDefs = useMemo(() => [
+  const columnDefsFactory = ({ onEdit, onDelete, onInfo }) => [
     { headerName: "Código", field: "codigo", flex: 1, sortable: true, filter: true },
     { headerName: "Nombre", field: "nombre", flex: 2, sortable: true, filter: true },
     {
       headerName: "Acciones",
       cellRenderer: 'actionsCellRenderer',
       cellRendererParams: {
-        onInfo: handleInfo,
-        onEdit: handleOpenModal,
-        onDelete: handleDeleteClick,
+        onInfo,
+        onEdit,
+        onDelete,
       },
       flex: 0.5,
       sortable: false,
@@ -98,80 +28,19 @@ function ProyectosPage() {
       resizable: false,
       pinned: 'right',
     }
-  ], []);
+  ];
 
   return (
-    <div className="h-full flex flex-col">
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold text-gray-800">Proyectos</h1>
-        <button
-          onClick={() => handleOpenModal()}
-          className="inline-flex items-center px-4 py-2 bg-indigo-600 text-white font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 shadow-sm transition-all duration-200 ease-in-out transform hover:scale-105"
-        >
-          <PlusIcon className="h-5 w-5 mr-2" />
-          Añadir Proyecto
-        </button>
-      </div>
-
-      <div className="flex-grow flex flex-col">
-        {loading ? (
-          <div className="bg-white shadow-lg rounded-lg overflow-hidden flex-grow">
-            <GridSkeletonLoader />
-          </div>
-        ) : proyectos.length === 0 ? (
-          <EmptyState
-            title="No hay proyectos"
-            message="Empieza por añadir tu primer proyecto para empezar a gestionarlos."
-            actionText="Añadir Proyecto"
-            onAction={() => handleOpenModal()}
-          />
-        ) : (
-          <div className="bg-white shadow-lg rounded-lg overflow-hidden flex-grow">
-            <DataGrid
-              rowData={proyectos}
-              columnDefs={columnDefs}
-              components={{
-                actionsCellRenderer: ActionsCellRenderer,
-              }}
-            />
-          </div>
-        )}
-      </div>
-
-      <Transition
-        show={modalOpen}
-        as={React.Fragment}
-        enter="transition-opacity duration-300"
-        enterFrom="opacity-0"
-        enterTo="opacity-100"
-        leave="transition-opacity duration-300"
-        leaveFrom="opacity-100"
-        leaveTo="opacity-0"
-      >
-        <ProyectoModal
-          open={modalOpen}
-          onClose={handleCloseModal}
-          onSave={handleSaveProyecto}
-          proyecto={editingProyecto}
-        />
-      </Transition>
-
-      <ConfirmDialog
-        open={confirmOpen}
-        onClose={() => setConfirmOpen(false)}
-        onConfirm={handleDeleteConfirm}
-        title="Confirmar Eliminación"
-        message="¿Estás seguro de que quieres eliminar este proyecto? Esta acción no se puede deshacer."
-      />
-
-      <InfoModal
-        open={infoModalOpen}
-        onClose={() => setInfoModalOpen(false)}
-        item={selectedProyecto}
-        title="Información del Proyecto"
-      />
-    </div>
+    <CrudPage
+      services={services}
+      columnDefsFactory={columnDefsFactory}
+      ModalComponent={ProyectoModal}
+      entityName="Proyecto"
+      entityNamePlural="Proyectos"
+      infoTitle="Información del Proyecto"
+      modalEntityPropName="proyecto"
+    />
   );
-}
+};
 
 export default ProyectosPage;


### PR DESCRIPTION
Refactored `ProveedoresPage.jsx` and `ProyectosPage.jsx` to use the generic `CrudPage.jsx` component.

This change eliminates a significant amount of duplicated code related to state management, data fetching, and UI rendering for CRUD operations. Both pages now follow the same standardized and simplified pattern already in use by `ClientesPage.jsx`, making the codebase cleaner and easier to maintain.