### PR TITLE
refactor: Replace alert() with notification system

### DIFF
--- a/src/components/InsumoModal.jsx
+++ b/src/components/InsumoModal.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { UNITS } from '../constants/units';
+import { useNotification } from '../hooks/useNotification';
 
 const InsumoModal = forwardRef(({ open, onClose, onSave, insumo }, ref) => {
+  const { addNotification } = useNotification();
   const getInitialFormData = () => ({
     codigo: '',
     descripcion: '',
@@ -50,7 +52,10 @@ const InsumoModal = forwardRef(({ open, onClose, onSave, insumo }, ref) => {
     // Basic validation
     for (const key in formData) {
       if (formData[key] === '') {
-        alert(`El campo ${key.replace('_', ' ')} es obligatorio.`);
+        addNotification({
+          message: `El campo ${key.replace('_', ' ')} es obligatorio.`,
+          type: 'error',
+        });
         return;
       }
     }

--- a/src/pages/SinopticoPage.jsx
+++ b/src/pages/SinopticoPage.jsx
@@ -23,10 +23,12 @@ import DraggableSinopticoNode from '../components/DraggableSinopticoNode';
 import SinopticoItemModal from '../components/SinopticoItemModal';
 import AuditLogModal from '../components/AuditLogModal';
 import { useFlattenedTree } from '../hooks/useFlattenedTree';
+import { useNotification } from '../hooks/useNotification';
 
 const SinopticoPage = () => {
   const { productId } = useParams();
   const navigate = useNavigate();
+  const { addNotification } = useNotification();
   const [hierarchy, setHierarchy] = useState(null);
   const [allItems, setAllItems] = useState([]);
   const [rootProduct, setRootProduct] = useState(null);
@@ -327,11 +329,11 @@ const SinopticoPage = () => {
   );
 
   const handleExportCSV = () => {
-    exportToCSV(hierarchy, `sinoptico-${rootProduct?.codigo || 'export'}.csv`);
+    exportToCSV(hierarchy, `sinoptico-${rootProduct?.codigo || 'export'}.csv`, addNotification);
   };
 
   const handleExportPDF = () => {
-    exportToPDF(hierarchy, `sinoptico-${rootProduct?.codigo || 'export'}.pdf`);
+    exportToPDF(hierarchy, `sinoptico-${rootProduct?.codigo || 'export'}.pdf`, addNotification);
   };
 
   return (

--- a/src/pages/SinopticoPage.test.jsx
+++ b/src/pages/SinopticoPage.test.jsx
@@ -83,13 +83,23 @@ const mockHierarchy = [
   ]}
 ];
 
+import { NotificationProvider } from '../contexts/NotificationProvider';
+
+const TestWrapper = ({ children }) => (
+  <MemoryRouter initialEntries={['/sinoptico/root1']}>
+    <NotificationProvider>
+      <Routes>
+        <Route path="/sinoptico/:productId" element={children} />
+      </Routes>
+    </NotificationProvider>
+  </MemoryRouter>
+);
+
 const renderComponent = () => {
   return render(
-    <MemoryRouter initialEntries={['/sinoptico/root1']}>
-      <Routes>
-        <Route path="/sinoptico/:productId" element={<SinopticoPage />} />
-      </Routes>
-    </MemoryRouter>
+    <TestWrapper>
+      <SinopticoPage />
+    </TestWrapper>
   );
 };
 

--- a/src/utils/fileExporters.js
+++ b/src/utils/fileExporters.js
@@ -30,9 +30,16 @@ const flattenHierarchy = (nodes, flattened = [], level = 0) => {
 };
 
 // Main function to export to CSV
-export const exportToCSV = (hierarchy, fileName = 'sinoptico.csv') => {
+export const exportToCSV = (hierarchy, fileName = 'sinoptico.csv', addNotification) => {
   if (!hierarchy || hierarchy.length === 0) {
-    alert('No hay datos para exportar.');
+    if (addNotification) {
+      addNotification({
+        message: 'No hay datos para exportar.',
+        type: 'warning',
+      });
+    } else {
+      alert('No hay datos para exportar.');
+    }
     return;
   }
 
@@ -74,9 +81,16 @@ import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 
 // Main function to export to PDF
-export const exportToPDF = (hierarchy, fileName = 'sinoptico.pdf') => {
+export const exportToPDF = (hierarchy, fileName = 'sinoptico.pdf', addNotification) => {
   if (!hierarchy || hierarchy.length === 0) {
-    alert('No hay datos para exportar.');
+    if (addNotification) {
+      addNotification({
+        message: 'No hay datos para exportar.',
+        type: 'warning',
+      });
+    } else {
+      alert('No hay datos para exportar.');
+    }
     return;
   }
 


### PR DESCRIPTION
Replaced `alert()` calls with the application's notification system for a better user experience.

- In `src/utils/fileExporters.js`, modified `exportToCSV` and `exportToPDF` to accept an `addNotification` function parameter for displaying a 'warning' notification when there is no data to export.
- In `src/pages/SinopticoPage.jsx`, implemented `useNotification` hook and passed the `addNotification` function to the exporter functions.
- In `src/components/InsumoModal.jsx`, replaced the validation `alert()` with an 'error' notification using the `useNotification` hook.
- Updated tests in `src/pages/SinopticoPage.test.jsx` to provide the `NotificationProvider` to avoid test failures.