### PR TITLE
feat: Update modal validation and use notifications

### DIFF
--- a/src/components/ClienteModal.jsx
+++ b/src/components/ClienteModal.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Dialog, Transition } from '@headlessui/react';
+import { useNotification } from '../hooks/useNotification';
 
 const ClienteModal = forwardRef(({ open, onClose, onSave, cliente }, ref) => {
+  const { addNotification } = useNotification();
   const [formData, setFormData] = useState({
     nombre: '',
     direccion: '',
@@ -35,7 +37,10 @@ const ClienteModal = forwardRef(({ open, onClose, onSave, cliente }, ref) => {
 
   const handleSave = () => {
     if (!formData.nombre) {
-      alert('Nombre es obligatorio.');
+      addNotification({
+        message: 'Nombre es obligatorio.',
+        type: 'error',
+      });
       return;
     }
     onSave(formData);

--- a/src/components/InsumoModal.jsx
+++ b/src/components/InsumoModal.jsx
@@ -49,15 +49,12 @@ const InsumoModal = forwardRef(({ open, onClose, onSave, insumo }, ref) => {
   };
 
   const handleSave = () => {
-    // Basic validation
-    for (const key in formData) {
-      if (formData[key] === '') {
-        addNotification({
-          message: `El campo ${key.replace('_', ' ')} es obligatorio.`,
-          type: 'error',
-        });
-        return;
-      }
+    if (!formData.codigo || !formData.descripcion) {
+      addNotification({
+        message: 'Código y Descripción son obligatorios.',
+        type: 'error',
+      });
+      return;
     }
     onSave(formData);
   };

--- a/src/components/ProductoModal.jsx
+++ b/src/components/ProductoModal.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { getProyectos } from '../services/modules/proyectosService';
+import { useNotification } from '../hooks/useNotification';
 
 const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
+  const { addNotification } = useNotification();
   const [formData, setFormData] = useState({
     codigo: '',
     descripcion: '',
@@ -47,8 +49,11 @@ const ProductoModal = forwardRef(({ open, onClose, onSave, producto }, ref) => {
   };
 
   const handleSave = () => {
-    if (!formData.codigo || !formData.descripcion || !formData.proyecto) {
-      alert('Todos los campos son obligatorios.');
+    if (!formData.codigo || !formData.descripcion) {
+      addNotification({
+        message: 'Código y Descripción son obligatorios.',
+        type: 'error',
+      });
       return;
     }
     onSave({ ...formData, unidad_medida: 'un' });

--- a/src/components/ProveedorModal.jsx
+++ b/src/components/ProveedorModal.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
+import { useNotification } from '../hooks/useNotification';
 
 const ProveedorModal = forwardRef(({ open, onClose, onSave, proveedor }, ref) => {
+  const { addNotification } = useNotification();
   const [formData, setFormData] = useState({
     razonSocial: '',
     direccion: '',
@@ -37,7 +39,10 @@ const ProveedorModal = forwardRef(({ open, onClose, onSave, proveedor }, ref) =>
 
   const handleSave = () => {
     if (!formData.razonSocial) {
-      alert('Razón Social es obligatoria.');
+      addNotification({
+        message: 'Razón Social es obligatoria.',
+        type: 'error',
+      });
       return;
     }
     onSave(formData);

--- a/src/components/ProyectoModal.jsx
+++ b/src/components/ProyectoModal.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
+import { useNotification } from '../hooks/useNotification';
 
 const ProyectoModal = forwardRef(({ open, onClose, onSave, proyecto }, ref) => {
+  const { addNotification } = useNotification();
   const [formData, setFormData] = useState({
     codigo: '',
     nombre: '',
@@ -28,7 +30,10 @@ const ProyectoModal = forwardRef(({ open, onClose, onSave, proyecto }, ref) => {
 
   const handleSave = () => {
     if (!formData.codigo || !formData.nombre) {
-      alert('Código y Nombre son obligatorios.');
+      addNotification({
+        message: 'Código y Nombre son obligatorios.',
+        type: 'error',
+      });
       return;
     }
     onSave(formData);

--- a/src/components/SubproductoModal.jsx
+++ b/src/components/SubproductoModal.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, Fragment, forwardRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
+import { useNotification } from '../hooks/useNotification';
 
 const SubproductoModal = forwardRef(({ open, onClose, onSave, subproducto }, ref) => {
+  const { addNotification } = useNotification();
   const [formData, setFormData] = useState({
     nombre: '',
     descripcion: '',
@@ -41,7 +43,10 @@ const SubproductoModal = forwardRef(({ open, onClose, onSave, subproducto }, ref
   const handleSave = () => {
     // Basic validation
     if (!formData.nombre || !formData.codigo) {
-      alert('Nombre y Código son campos obligatorios.');
+      addNotification({
+        message: 'Nombre y Código son obligatorios.',
+        type: 'error',
+      });
       return;
     }
     onSave({ ...formData, unidad_medida: 'un' });


### PR DESCRIPTION
This commit modifies six modal components to align with new validation requirements and to improve user feedback.

The validation logic in `handleSave` for each of the following modals has been updated to only require the specified fields:
- `ProveedorModal`: `razonSocial`
- `ProyectoModal`: `codigo`, `nombre`
- `ProductoModal`: `codigo`, `descripcion`
- `SubproductoModal`: `nombre`, `codigo`
- `ClienteModal`: `nombre`
- `InsumoModal`: `codigo`, `descripcion`

Additionally, all `alert()` calls within these components have been replaced with a custom `useNotification` hook, providing a more consistent and modern user experience for displaying validation errors.