### PR TITLE
feat(sinoptico): Rediseña la carátula y mejora la adición de hijos

### DIFF
--- a/src/components/AddItemFromDBModal.jsx
+++ b/src/components/AddItemFromDBModal.jsx
@@ -1,0 +1,129 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { getInsumos } from '../services/modules/insumosService';
+import { getSubproductos } from '../services/modules/subproductosService';
+import { XMarkIcon } from '@heroicons/react/24/solid';
+
+const AddItemFromDBModal = ({ isOpen, onClose, onAddItems, parentId, rootProductId }) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [items, setItems] = useState([]);
+  const [selectedItems, setSelectedItems] = useState(new Set());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      const fetchItems = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+          const [insumos, subproductos] = await Promise.all([
+            getInsumos(),
+            getSubproductos()
+          ]);
+          const combined = [
+            ...insumos.map(i => ({ ...i, type: 'insumo' })),
+            ...subproductos.map(s => ({ ...s, type: 'subproducto' })),
+          ];
+          setItems(combined);
+        } catch (err) {
+          setError('No se pudieron cargar los items.');
+          console.error(err);
+        } finally {
+          setLoading(false);
+        }
+      };
+      fetchItems();
+    }
+  }, [isOpen]);
+
+  const filteredItems = useMemo(() => {
+    return items.filter(item =>
+      item.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      item.codigo.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  }, [items, searchTerm]);
+
+  const handleToggleSelection = (itemId) => {
+    setSelectedItems(prev => {
+      const newSelection = new Set(prev);
+      if (newSelection.has(itemId)) {
+        newSelection.delete(itemId);
+      } else {
+        newSelection.add(itemId);
+      }
+      return newSelection;
+    });
+  };
+
+  const handleAddClick = () => {
+    onAddItems(Array.from(selectedItems));
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center p-4">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+        <div className="flex justify-between items-center p-4 border-b">
+          <h2 className="text-xl font-bold">Añadir Items desde la Base de Datos</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <XMarkIcon className="h-6 w-6" />
+          </button>
+        </div>
+
+        <div className="p-4">
+          <input
+            type="text"
+            placeholder="Buscar por nombre o código..."
+            className="w-full px-3 py-2 border border-gray-300 rounded-md"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+
+        <div className="overflow-y-auto flex-grow p-4">
+          {loading && <p>Cargando...</p>}
+          {error && <p className="text-red-500">{error}</p>}
+          {!loading && !error && (
+            <ul className="divide-y divide-gray-200">
+              {filteredItems.map(item => (
+                <li
+                  key={item.id}
+                  className={`flex items-center justify-between p-3 cursor-pointer ${selectedItems.has(item.id) ? 'bg-blue-100' : 'hover:bg-gray-50'}`}
+                  onClick={() => handleToggleSelection(item.id)}
+                >
+                  <div>
+                    <p className="font-semibold">{item.nombre}</p>
+                    <p className="text-sm text-gray-500">{item.codigo} - <span className="capitalize">{item.type}</span></p>
+                  </div>
+                  <input
+                    type="checkbox"
+                    checked={selectedItems.has(item.id)}
+                    readOnly
+                    className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex justify-end p-4 border-t">
+          <button onClick={onClose} className="px-4 py-2 mr-2 rounded-md text-gray-700 bg-gray-200 hover:bg-gray-300">
+            Cancelar
+          </button>
+          <button
+            onClick={handleAddClick}
+            disabled={selectedItems.size === 0}
+            className="px-4 py-2 rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300"
+          >
+            Añadir {selectedItems.size > 0 ? `(${selectedItems.size})` : ''}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddItemFromDBModal;

--- a/src/components/Caratula.jsx
+++ b/src/components/Caratula.jsx
@@ -155,52 +155,68 @@ function Caratula() {
           </div>
         </div>
       ) : (
-        <dl className="grid grid-cols-1 md:grid-cols-4 gap-x-6 gap-y-8">
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">PROYECTO</dt>
-            <dd className="mt-1 text-lg text-gray-900">{getProjectName(caratulaData.proyectoId)}</dd>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-6">
+          {/* Columna 1: Datos del Proyecto */}
+          <div className="p-4 border border-gray-200 rounded-lg">
+            <h3 className="text-lg font-semibold text-gray-700 mb-4 border-b pb-2">Datos del Proyecto</h3>
+            <dl className="space-y-4">
+              <div>
+                <dt className="text-sm font-medium text-gray-500">PROYECTO</dt>
+                <dd className="mt-1 text-md text-gray-900">{getProjectName(caratulaData.proyectoId)}</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Fecha de emisión</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.fechaEmision || 'N/A'}</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Revisión</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.revision || 'N/A'}</dd>
+              </div>
+            </dl>
           </div>
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">Fecha de emisión</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.fechaEmision || 'N/A'}</dd>
-          </div>
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">Revisión</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.revision || 'N/A'}</dd>
-          </div>
-          <div className="sm:col-span-1"></div>
 
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">NOMBRE DE PARTE</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.nombreParte || 'N/A'}</dd>
+          {/* Columna 2: Datos de la Parte */}
+          <div className="p-4 border border-gray-200 rounded-lg">
+            <h3 className="text-lg font-semibold text-gray-700 mb-4 border-b pb-2">Datos de la Parte</h3>
+            <dl className="space-y-4">
+              <div>
+                <dt className="text-sm font-medium text-gray-500">NOMBRE DE PARTE</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.nombreParte || 'N/A'}</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">NÚMERO DE PARTE</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.numeroParte || 'N/A'}</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Versión</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.version || 'N/A'}</dd>
+              </div>
+            </dl>
           </div>
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">Realizó</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.elaboradoPor || 'N/A'}</dd>
-          </div>
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">Fecha revisión</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.fechaRevision || 'N/A'}</dd>
-          </div>
-          <div className="sm:col-span-1"></div>
 
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">NÚMERO DE PARTE</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.numeroParte || 'N/A'}</dd>
+          {/* Columna 3: Datos de Revisión */}
+          <div className="p-4 border border-gray-200 rounded-lg">
+            <h3 className="text-lg font-semibold text-gray-700 mb-4 border-b pb-2">Datos de Revisión</h3>
+            <dl className="space-y-4">
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Realizó</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.elaboradoPor || 'N/A'}</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Fecha revisión</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.fechaRevision || 'N/A'}</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Autor</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.autor || 'N/A'}</dd>
+              </div>
+              <div>
+                <dt className="text-sm font-medium text-gray-500">Revisado por</dt>
+                <dd className="mt-1 text-md text-gray-900">{caratulaData.revisadoPor || 'N/A'}</dd>
+              </div>
+            </dl>
           </div>
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">Versión</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.version || 'N/A'}</dd>
-          </div>
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">Autor</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.autor || 'N/A'}</dd>
-          </div>
-          <div className="sm:col-span-1">
-            <dt className="text-sm font-medium text-gray-500">Revisado por</dt>
-            <dd className="mt-1 text-lg text-gray-900">{caratulaData.revisadoPor || 'N/A'}</dd>
-          </div>
-        </dl>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Se implementan dos mejoras principales en el módulo Sinóptico:

1.  Rediseño de la Carátula: Se ha mejorado el diseño de la vista de solo lectura del componente `Caratula.jsx`. Los campos se han reorganizado en una grilla de tres columnas, agrupando la información de manera lógica (Datos del Proyecto, Datos de la Parte, Datos de Revisión) para una mejor legibilidad y una apariencia más profesional.

2.  Mejora al Añadir Hijos: Se ha modificado el flujo para añadir ítems hijos en la página del Sinóptico. Ahora, al hacer clic en "Añadir Item Hijo", se abre un nuevo modal (`AddItemFromDBModal.jsx`) que permite buscar y seleccionar `insumos` y `subproductos` existentes en la base de datos. Los ítems seleccionados se añaden como hijos del producto principal, creando copias de los mismos en la jerarquía del sinóptico.