### PR TITLE
feat: Enhance SinopticoNode to function as a table row

### DIFF
--- a/src/components/SinopticoNode.jsx
+++ b/src/components/SinopticoNode.jsx
@@ -88,8 +88,8 @@ const SinopticoNode = ({ node, level, editMode, onEdit, onQuickUpdate, onOpenAud
 
   return (
     <div className={`relative ${editMode ? 'border border-gray-200 rounded-md' : ''}`}>
-      <div className={`grid grid-cols-9 gap-4 px-4 py-3 items-center ${editMode ? 'hover:bg-gray-50' : ''}`}>
-        <div className="col-span-3 flex items-center relative" style={indentation}>
+      <div className={`grid grid-cols-12 gap-4 px-4 py-3 items-center ${editMode ? 'hover:bg-gray-50' : ''}`}>
+        <div className="col-span-2 flex items-center relative" style={indentation}>
           {hasChildren ? (
             <button onClick={() => onToggleNode(node.id)} className="w-6 mr-2 text-gray-500 z-10 focus:outline-none">
               {isCollapsed ? <ChevronRightIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
@@ -100,6 +100,9 @@ const SinopticoNode = ({ node, level, editMode, onEdit, onQuickUpdate, onOpenAud
           <div className="font-medium text-gray-800 w-full">{renderEditableCell('nombre', node.nombre || node.descripcion)}</div>
         </div>
         <div className="text-gray-600 w-full">{renderEditableCell('codigo', node.codigo)}</div>
+        <div className="text-gray-600">{renderEditableCell('cantidad', node.cantidad)}</div>
+        <div className="text-gray-600">{node.unidadDeMedida || 'N/A'}</div>
+        <div className="text-gray-600 col-span-2">{renderEditableCell('comentarios', node.comentarios)}</div>
         <div>
           <span className={`px-2 py-1 text-xs font-semibold rounded-full ${typeColor[node.type] || 'bg-gray-100 text-gray-800'}`}>
             {node.type || 'N/A'}

--- a/src/pages/SinopticoPage.jsx
+++ b/src/pages/SinopticoPage.jsx
@@ -321,9 +321,12 @@ const SinopticoPage = () => {
   };
 
   const renderHeader = () => (
-    <div className="grid grid-cols-9 gap-4 px-4 py-2 bg-gray-200 text-gray-700 font-bold rounded-t-lg">
-      <div className="col-span-3">Nombre</div>
+    <div className="grid grid-cols-12 gap-4 px-4 py-2 bg-gray-200 text-gray-700 font-bold rounded-t-lg">
+      <div className="col-span-2">Nombre</div>
       <div>Código</div>
+      <div>Cantidad</div>
+      <div>Unidad de Medida</div>
+      <div className="col-span-2">Comentarios</div>
       <div>Tipo</div>
       <div>Version</div>
       <div>Cód. Cliente</div>


### PR DESCRIPTION
This commit modifies the SinopticoNode.jsx component to behave like a table row with additional columns.

- Adds 'Cantidad', 'Unidad de Medida', and 'Comentarios' columns to the view.
- Aligns the new columns using a CSS grid layout, adjusting the number of columns from 9 to 12.
- Implements in-line editing on double-click for the 'Cantidad' and 'Comentarios' fields by reusing the existing `renderEditableCell` logic.
- Updates the header in `SinopticoPage.jsx` to match the new column structure in `SinopticoNode.jsx`.