### PR TITLE
Fix: Handle undefined properties in AddItemFromDBModal

### DIFF
--- a/src/components/AddItemFromDBModal.jsx
+++ b/src/components/AddItemFromDBModal.jsx
@@ -37,10 +37,14 @@ const AddItemFromDBModal = ({ isOpen, onClose, onAddItems, parentId, rootProduct
   }, [isOpen]);
 
   const filteredItems = useMemo(() => {
-    return items.filter(item =>
-      item.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      item.codigo.toLowerCase().includes(searchTerm.toLowerCase())
-    );
+    if (!items) return [];
+    return items.filter(item => {
+        const nombre = item.nombre || '';
+        const codigo = item.codigo || '';
+        const term = searchTerm.toLowerCase();
+        return nombre.toLowerCase().includes(term) ||
+               codigo.toLowerCase().includes(term);
+    });
   }, [items, searchTerm]);
 
   const handleToggleSelection = (itemId) => {


### PR DESCRIPTION
This commit fixes a TypeError that occurred in the `AddItemFromDBModal` component when filtering items. The error was caused by calling `toLowerCase()` on `item.nombre` or `item.codigo` without first checking if these properties existed.

The `filteredItems` `useMemo` hook has been updated to provide default empty string values for `nombre` and `codigo` if they are null or undefined. This makes the filtering logic more robust and prevents the application from crashing when encountering items with missing properties.