### PR TITLE
feat: Make Caratula component fully dynamic

### DIFF
--- a/src/components/Caratula.jsx
+++ b/src/components/Caratula.jsx
@@ -9,11 +9,14 @@ const InfoCell = ({ label, value, className = '' }) => (
   </div>
 );
 
-const Caratula = ({ rootProduct }) => {
-  // Static data for demonstration
-  const realizadoPor = "Nombre del Realizador";
-  const fechaRealizacion = new Date().toLocaleDateString();
-  const revisadoPor = "Nombre del Revisor";
+const Caratula = ({ rootProduct, projectData }) => {
+  const getDisplayValue = (value) => value || 'N/A';
+
+  const formatDate = (timestamp) => {
+    if (!timestamp) return 'N/A';
+    // Assuming timestamp is a Firebase Timestamp object
+    return timestamp.toDate ? timestamp.toDate().toLocaleDateString() : new Date(timestamp).toLocaleDateString();
+  };
 
   return (
     <div className="bg-surface shadow-lg border border-gray-200 w-full max-w-5xl mx-auto my-8">
@@ -26,27 +29,25 @@ const Caratula = ({ rootProduct }) => {
         {/* Project Title Section */}
         <div className="col-span-8 flex items-center justify-center p-4 bg-primary text-white">
           <h1 className="text-2xl font-bold text-center">
-            {rootProduct ? rootProduct.nombre : "Nombre del Proyecto"}
+            {getDisplayValue(projectData?.nombre)}
           </h1>
         </div>
 
         {/* Data Grid */}
         <div className="col-span-12 grid grid-cols-4 border-t border-gray-300">
-          <InfoCell label="Realizado por" value={realizadoPor} />
-          <InfoCell label="Fecha de realización" value={fechaRealizacion} />
-          <InfoCell label="Revisado por" value={revisadoPor} />
-          <InfoCell label="Última Modificación" value={new Date().toLocaleDateString()} />
+          <InfoCell label="Realizado por" value={getDisplayValue(rootProduct?.createdBy)} />
+          <InfoCell label="Fecha de realización" value={formatDate(rootProduct?.createdAt)} />
+          <InfoCell label="Revisado por" value={getDisplayValue(projectData?.revisadoPor)} />
+          <InfoCell label="Última Modificación" value={formatDate(rootProduct?.lastModifiedAt)} />
         </div>
 
         {/* Dynamic Project Data */}
-        {rootProduct && (
-          <div className="col-span-12 grid grid-cols-4">
-            <InfoCell label="Código" value={rootProduct.codigo} />
-            <InfoCell label="Descripción" value={rootProduct.descripcion} />
-            <InfoCell label="Cliente" value={rootProduct.cliente} />
-            <InfoCell label="Estado" value={rootProduct.estado} />
-          </div>
-        )}
+        <div className="col-span-12 grid grid-cols-4">
+          <InfoCell label="Código del Proyecto" value={getDisplayValue(projectData?.codigo)} />
+          <InfoCell label="Cliente" value={getDisplayValue(projectData?.cliente)} />
+          <InfoCell label="Código del Producto" value={getDisplayValue(rootProduct?.codigo)} />
+          <InfoCell label="Versión del Producto" value={getDisplayValue(rootProduct?.version)} />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/SinopticoPage.jsx
+++ b/src/pages/SinopticoPage.jsx
@@ -15,6 +15,7 @@ import {
 } from '@dnd-kit/sortable';
 import { getHierarchyForProduct, createNewChildItem, moveSinopticoItem, updateItemsOrder, addExistingItemsAsChildren } from '../services/sinopticoService';
 import { updateSinopticoItem, getSinopticoItems } from '../services/modules/sinopticoItemsService';
+import { getProyectoById } from '../services/modules/proyectosService';
 import { exportToCSV, exportToPDF } from '../utils/fileExporters';
 import EmptyState from '../components/EmptyState';
 import GridSkeletonLoader from '../components/GridSkeletonLoader';
@@ -36,6 +37,7 @@ const SinopticoPage = () => {
   const [hierarchy, setHierarchy] = useState(null);
   const [allItems, setAllItems] = useState([]);
   const [rootProduct, setRootProduct] = useState(null);
+  const [projectData, setProjectData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [editMode, setEditMode] = useState(false);
@@ -104,6 +106,11 @@ const SinopticoPage = () => {
 
       const rootItem = allItemsData.find(item => item.id === productId);
       setRootProduct(rootItem);
+
+      if (rootItem && rootItem.proyecto) {
+        const project = await getProyectoById(rootItem.proyecto);
+        setProjectData(project);
+      }
 
       if (!tree || tree.length === 0) {
         setHierarchy(null);
@@ -369,7 +376,7 @@ const SinopticoPage = () => {
   return (
     <div className="p-6 bg-gray-50 min-h-full">
       <div className="max-w-7xl mx-auto">
-        <Caratula />
+        <Caratula rootProduct={rootProduct} projectData={projectData} />
         <div className="flex justify-between items-center mb-4">
           <button onClick={() => navigate('/productos')} className="text-blue-600 hover:underline">
             &larr; Volver a Productos

--- a/src/services/modules/proyectosService.js
+++ b/src/services/modules/proyectosService.js
@@ -1,5 +1,5 @@
 import { createCrudService } from '../firebaseServiceFactory';
-import { db, collection, getDocs } from '../firebase';
+import { db, doc, getDoc } from '../firebase';
 
 const PROYECTOS_COLLECTION = 'proyectos';
 
@@ -9,3 +9,24 @@ export const getProyectos = proyectoCrudService.get;
 export const addProyecto = proyectoCrudService.add;
 export const updateProyecto = proyectoCrudService.update;
 export const deleteProyecto = proyectoCrudService.delete;
+
+export const getProyectoById = async (id) => {
+  if (!id) {
+    console.error("ID de proyecto no proporcionado.");
+    return null;
+  }
+  try {
+    const docRef = doc(db, PROYECTOS_COLLECTION, id);
+    const docSnap = await getDoc(docRef);
+
+    if (docSnap.exists()) {
+      return { id: docSnap.id, ...docSnap.data() };
+    } else {
+      console.log("No se encontró el documento del proyecto!");
+      return null;
+    }
+  } catch (error) {
+    console.error("Error al obtener el documento del proyecto:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
- Removes all static data from the Caratula component.
- Uses the `rootProduct` prop to display real product information.
- Adds a new `getProyectoById` function to `proyectosService.js` to fetch project data.
- Updates `SinopticoPage.jsx` to fetch project data and pass it to the Caratula component.
- The Caratula now displays dynamic information from both `rootProduct` and `projectData`.