### PR TITLE
fix(sinoptico): Correct data destructuring from getSinopticoItems

### DIFF
--- a/src/pages/SinopticoPage.jsx
+++ b/src/pages/SinopticoPage.jsx
@@ -96,7 +96,7 @@ const SinopticoPage = () => {
   const fetchHierarchy = useCallback(async () => {
     try {
       setLoading(true);
-      const [tree, { data: allItemsData }] = await Promise.all([
+      const [tree, allItemsData] = await Promise.all([
         getHierarchyForProduct(productId),
         getSinopticoItems()
       ]);

--- a/src/pages/SinopticoPage.test.jsx
+++ b/src/pages/SinopticoPage.test.jsx
@@ -142,7 +142,7 @@ describe('SinopticoPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sinopticoService.getHierarchyForProduct.mockResolvedValue(JSON.parse(JSON.stringify(mockHierarchy)));
-    getSinopticoItems.mockResolvedValue({ data: mockAllItems, lastVisible: null });
+    getSinopticoItems.mockResolvedValue(mockAllItems);
     updateSinopticoItem.mockResolvedValue(true);
     sinopticoService.moveSinopticoItem.mockResolvedValue(true);
   });


### PR DESCRIPTION
The SinopticoPage was encountering `TypeError` exceptions (`find` and `map` on undefined) because it was incorrectly destructuring the result from the `getSinopticoItems` service.

The component expected an object `{ data: [...] }` while the service returned a plain array `[...]`. This resulted in the `allItemsData` variable being undefined, causing subsequent method calls on it to fail.

This commit corrects the destructuring in `SinopticoPage.jsx` to handle the array directly.

Additionally, the corresponding mock in `SinopticoPage.test.jsx` has been updated to reflect the actual data structure returned by the service, ensuring tests pass and are accurate.